### PR TITLE
feature/NPC-walking-fixes

### DIFF
--- a/Assets/GothicVR/Resources/Prefabs/Vobs/zCVobSpot.prefab
+++ b/Assets/GothicVR/Resources/Prefabs/Vobs/zCVobSpot.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 5681108792341746749}
   - component: {fileID: 4250102412515220408}
   - component: {fileID: 3429925256554951498}
-  - component: {fileID: 5979848652310601961}
   m_Layer: 2
   m_Name: zCVobSpot
   m_TagString: PxVob_zCVobSpot
@@ -98,24 +97,3 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &5979848652310601961
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3434156045681339339}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 0.5
-  m_Center: {x: 0, y: -0.0000019073486, z: -0.000015258789}

--- a/Assets/GothicVR/Resources/Prefabs/WayPoint.prefab
+++ b/Assets/GothicVR/Resources/Prefabs/WayPoint.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 2665078943939252271}
   - component: {fileID: 1188047755481711733}
   - component: {fileID: 6851058351796696224}
-  - component: {fileID: 3747938385529500483}
   m_Layer: 2
   m_Name: WayPoint
   m_TagString: Untagged
@@ -84,24 +83,3 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &3747938385529500483
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4344130464614125633}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/GothicVR/Scripts/Debugging/GvrGizmosDebug.cs
+++ b/Assets/GothicVR/Scripts/Debugging/GvrGizmosDebug.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace GVR.Debugging
+{
+    /// <summary>
+    /// Add it to an object where you want to draw some information.
+    /// </summary>
+    public class GvrGizmosDebug : MonoBehaviour
+    {
+        private void OnDrawGizmos()
+        {
+            var pos = transform.position;
+            var up = new Vector3(pos.x, 100, pos.z);
+            var down = new Vector3(pos.x, -100, pos.z);
+
+            Gizmos.DrawLine(up, down);
+        }
+    }
+}

--- a/Assets/GothicVR/Scripts/Debugging/GvrGizmosDebug.cs.meta
+++ b/Assets/GothicVR/Scripts/Debugging/GvrGizmosDebug.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 859e6fbc7b9044cf915d1bc21e44e2c0
+timeCreated: 1717391267

--- a/Assets/GothicVR/Scripts/Globals/Constants.cs
+++ b/Assets/GothicVR/Scripts/Globals/Constants.cs
@@ -55,6 +55,10 @@ namespace GVR.Globals
         // We need to set the scale so that collision and NPC animation is starting at the right spot.
         public static Vector3 VobZSScale = new(0.1f, 0.1f, 0.1f);
 
+        // e.g. for NPCs to check if they reached a FreePoint already. Value is based on best guess/testing.
+        public const float CloseToThreshold = 0.6f;
+
+
         static Constants()
         {
             LoadingMaterial = new Material(ShaderWorldLit);

--- a/Assets/GothicVR/Scripts/Manager/NpcHelper.cs
+++ b/Assets/GothicVR/Scripts/Manager/NpcHelper.cs
@@ -19,7 +19,7 @@ namespace GVR.Manager
 {
     public static class NpcHelper
     {
-        private const float fpLookupDistance = 20f; // meter
+        private const float fpLookupDistance = 7f; // meter
 
         static NpcHelper()
         {

--- a/Assets/GothicVR/Scripts/Npc/Actions/AnimationActions/AbstractAnimationAction.cs
+++ b/Assets/GothicVR/Scripts/Npc/Actions/AnimationActions/AbstractAnimationAction.cs
@@ -133,21 +133,11 @@ namespace GVR.Npc.Actions.AnimationActions
             IsFinishedFlag = true;
         }
 
-        public virtual void OnCollisionEnter(Collision coll)
-        { }
-        public virtual void OnTriggerEnter(Collider coll)
-        { }
-
-        public virtual void OnCollisionExit(Collision coll)
-        { }
-        public virtual void OnTriggerExit(Collider coll)
-        { }
-        
         /// <summary>
         /// Called every update cycle.
         /// Can be used to handle frequent things internally.
         /// </summary>
-        public virtual void Tick(Transform transform)
+        public virtual void Tick()
         { }
 
         /// <summary>

--- a/Assets/GothicVR/Scripts/Npc/Actions/AnimationActions/AbstractRotateAnimationAction.cs
+++ b/Assets/GothicVR/Scripts/Npc/Actions/AnimationActions/AbstractRotateAnimationAction.cs
@@ -51,11 +51,11 @@ namespace GVR.Npc.Actions.AnimationActions
             }
         }
 
-        public override void Tick(Transform transform)
+        public override void Tick()
         {
-            base.Tick(transform);
+            base.Tick();
 
-            HandleRotation(transform);
+            HandleRotation(NpcGo.transform);
         }
 
         /// <summary>

--- a/Assets/GothicVR/Scripts/Npc/Actions/AnimationActions/GoToFp.cs
+++ b/Assets/GothicVR/Scripts/Npc/Actions/AnimationActions/GoToFp.cs
@@ -23,21 +23,6 @@ namespace GVR.Npc.Actions.AnimationActions
 
             var npcPos = NpcGo.transform.position;
             fp = WayNetHelper.FindNearestFreePoint(npcPos, destination);
-
-            // Fix - If NPC is spawned directly in front of the FP, we start transition immediately (otherwise trigger/collider won't be called).
-            if (Vector3.Distance(npcPos, fp!.Position) < 1f)
-                FreePointReached();
-        }
-
-        public override void OnTriggerEnter(Collider coll)
-        {
-            if (walkState != WalkState.Walk)
-                return;
-
-            if (coll.gameObject.name != fp.Name)
-                return;
-
-            FreePointReached();
         }
 
         public override void AnimationEndEventCallback(SerializableEventEndSignal eventData)
@@ -52,7 +37,7 @@ namespace GVR.Npc.Actions.AnimationActions
             return fp.Position;
         }
 
-        private void FreePointReached()
+        protected override void OnDestinationReached()
         {
             Props.CurrentFreePoint = fp;
             fp.IsLocked = true;

--- a/Assets/GothicVR/Scripts/Npc/Actions/AnimationActions/GoToNpc.cs
+++ b/Assets/GothicVR/Scripts/Npc/Actions/AnimationActions/GoToNpc.cs
@@ -33,5 +33,13 @@ namespace GVR.Npc.Actions.AnimationActions
 
             IsFinishedFlag = false;
         }
+
+        protected override void OnDestinationReached()
+        {
+            AnimationEndEventCallback(new SerializableEventEndSignal(nextAnimation: ""));
+
+            walkState = WalkState.Done;
+            IsFinishedFlag = true;
+        }
     }
 }

--- a/Assets/GothicVR/Scripts/Npc/Actions/AnimationActions/GoToWp.cs
+++ b/Assets/GothicVR/Scripts/Npc/Actions/AnimationActions/GoToWp.cs
@@ -38,31 +38,6 @@ namespace GVR.Npc.Actions.AnimationActions
                 destinationWaypoint.Name));
         }
 
-        public override void OnTriggerEnter(Collider coll)
-        {
-            if (walkState != WalkState.Walk)
-                return;
-
-            if (coll.gameObject.name != route.First().Name)
-                return;
-
-            // FIXME - get current waypoint object
-            // props.currentWayPoint = coll.gameObject.
-
-            route.Pop();
-
-            if (route.Count == 0)
-            {
-                walkState = WalkState.Done;
-                IsFinishedFlag = true;
-            }
-            else
-            {
-                // A new waypoint is destination, we therefore rotate NPC again.
-                walkState = WalkState.WalkAndRotate;
-            }
-        }
-
         protected override Vector3 GetWalkDestination()
         {
             return route.Peek().Position;
@@ -73,6 +48,24 @@ namespace GVR.Npc.Actions.AnimationActions
             base.AnimationEndEventCallback(eventData);
 
             IsFinishedFlag = false;
+        }
+
+        protected override void OnDestinationReached()
+        {
+            route.Pop();
+
+            if (route.Count == 0)
+            {
+                AnimationEndEventCallback(new SerializableEventEndSignal(nextAnimation: ""));
+
+                walkState = WalkState.Done;
+                IsFinishedFlag = true;
+            }
+            else
+            {
+                // A new waypoint is destination, we therefore rotate NPC again.
+                walkState = WalkState.WalkAndRotate;
+            }
         }
     }
 }

--- a/Assets/GothicVR/Scripts/Npc/Actions/AnimationActions/UseMob.cs
+++ b/Assets/GothicVR/Scripts/Npc/Actions/AnimationActions/UseMob.cs
@@ -58,10 +58,6 @@ namespace GVR.Npc.Actions.AnimationActions
             Props.currentInteractable = mobGo;
             Props.currentInteractableSlot = slotGo;
             Props.bodyState = VmGothicEnums.BodyState.BS_MOBINTERACT;
-
-            // Fix - If NPC is spawned directly in front of the Mob, we start transition immediately (otherwise trigger/collider won't be called).
-            if (Vector3.Distance(NpcGo.transform.position, slotGo.transform.position) < 0.5f)
-                StartMobUseAnimation();
         }
 
         [CanBeNull]
@@ -83,14 +79,8 @@ namespace GVR.Npc.Actions.AnimationActions
             return slot;
         }
 
-        public override void OnTriggerEnter(Collider coll)
+        protected override void OnDestinationReached()
         {
-            if (walkState != WalkState.Walk)
-                return;
-
-            if (coll.gameObject != slotGo)
-                return;
-
             StartMobUseAnimation();
         }
 

--- a/Assets/GothicVR/Scripts/Npc/AiHandler.cs
+++ b/Assets/GothicVR/Scripts/Npc/AiHandler.cs
@@ -30,7 +30,7 @@ namespace GVR.Npc
         /// </summary>
         private void Update()
         {
-            properties.currentAction.Tick(transform);
+            properties.currentAction.Tick();
           
             // Add new milliseconds when stateTime shall be measured.
             if (properties.isStateTimeActive)

--- a/Assets/GothicVR/Scripts/Npc/RootCollisionHandler.cs
+++ b/Assets/GothicVR/Scripts/Npc/RootCollisionHandler.cs
@@ -6,43 +6,6 @@ namespace GVR.Npc
 {
     public class RootCollisionHandler : BasePlayerBehaviour
     {
-        private void OnCollisionEnter(Collision coll)
-        {
-            properties.currentAction?.OnCollisionEnter(coll);
-        }
-
-        private void OnTriggerEnter(Collider coll)
-        {
-            properties.currentAction?.OnTriggerEnter(coll);
-        }
-
-        private void OnCollisionExit(Collision coll)
-        {
-            properties.currentAction?.OnCollisionExit(coll);
-
-            // FIXME - As we handle FreePoint locking via Colliders, we can't just say "free" whenever collider is left as a rotation can create this state already.
-            // FIXME - Instead we need to handle unlocking via game logic. E.g. whenever a new state starts, clear our NPCs lock setting.
-            // // If NPC walks out of a FreePoint, it gets freed.
-            // if (coll.gameObject.name.StartsWithIgnoreCase("FP_") &&
-            //     coll.gameObject.TryGetComponent<VobSpotProperties>(out var vobSpotProperties))
-            //     vobSpotProperties.fp.IsLocked = false;
-        }
-
-        /// <summary>
-        /// Sometimes a currentAnimation needs this information. Sometimes it's just for a FreePoint to clear up.
-        /// </summary>
-        private void OnTriggerExit(Collider coll)
-        {
-            properties.currentAction?.OnTriggerExit(coll);
-
-            // FIXME - As we handle FreePoint locking via Colliders, we can't just say "free" whenever collider is left as a rotation can create this state already.
-            // FIXME - Instead we need to handle unlocking via game logic. E.g. whenever a new state starts, clear our NPCs lock setting.
-            // // If NPC walks out of a FreePoint, it gets freed.
-            // if (coll.gameObject.name.StartsWithIgnoreCase("FP_") &&
-            //     coll.gameObject.TryGetComponent<VobSpotProperties>(out var vobSpotProperties))
-            //     vobSpotProperties.fp.IsLocked = false;
-        }
-
         private void Update()
         {
             // As we use legacy animations, we can't use RootMotion. We therefore need to rebuild it.

--- a/Assets/Plugins/Editor.meta
+++ b/Assets/Plugins/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 858ac920a738b50478a8954ff5356f6e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
What's done:
* I changed lookup of end locations from Sphere Colliders of Waypoints/Freepoints to a Vector.Distance() lookup. Due to the fact, that some NPCs spawn directly next or inside a collider, which causes frictions. The new lookup is better aligned with original Gothic logic.

# To test
1. Spawn Grim (580) a few times and look if he walks into the music stage - if he just stands around the fire, we're fine. (Lowered search distance for a place to pee. Before the fix, he walked into the inner circle's walls to pee)
2. Guard (214) should stay in front of door (Before the fix, he walked through walls)
