### PR TITLE
Feature/dynamic prefab loading

### DIFF
--- a/Assets/Gothic-UnZENity-Core/Resources/Prefabs/Vobs/oCMobLadder.prefab
+++ b/Assets/Gothic-UnZENity-Core/Resources/Prefabs/Vobs/oCMobLadder.prefab
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6503575194566409312
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2022050282646122291}
+  - component: {fileID: 5252305678164495226}
+  m_Layer: 0
+  m_Name: oCMobLadder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2022050282646122291
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6503575194566409312}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.69465834, y: 0, z: 0, w: 0.71933985}
+  m_LocalPosition: {x: -328.3223, y: 27.197954, z: -177.9182}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 88, y: 0, z: 0}
+--- !u!114 &5252305678164495226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6503575194566409312}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 024fa582612e45c0afcf4ba9d756341e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <visualScheme>k__BackingField: 

--- a/Assets/Gothic-UnZENity-Core/Resources/Prefabs/Vobs/oCMobLadder.prefab.meta
+++ b/Assets/Gothic-UnZENity-Core/Resources/Prefabs/Vobs/oCMobLadder.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d01d3313c0c1af4488e9ccf60e7b183a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Gothic-UnZENity-Core/Scripts/Caches/PrefabCache.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Caches/PrefabCache.cs
@@ -25,6 +25,7 @@ namespace GUZ.Core.Caches
             VobMusic,
             VobSound,
             VobSoundDaytime,
+            VobLadder,
             XRDeviceSimulator
         }
 
@@ -46,6 +47,7 @@ namespace GUZ.Core.Caches
                 PrefabType.VobMusic => "Prefabs/Vobs/oCZoneMusic",
                 PrefabType.VobSound => "Prefabs/Vobs/zCVobSound",
                 PrefabType.VobSoundDaytime => "Prefabs/Vobs/zCVobSoundDaytime",
+                PrefabType.VobLadder => "Prefabs/Vobs/oCMobLadder",
                 PrefabType.XRDeviceSimulator => "Prefabs/XR Device Simulator",
                 _ => throw new Exception($"Enum value {type} not yet defined.")
             };

--- a/Assets/Gothic-UnZENity-Core/Scripts/Creator/Meshes/V2/Builder/AbstractMeshBuilder.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Creator/Meshes/V2/Builder/AbstractMeshBuilder.cs
@@ -151,8 +151,8 @@ namespace GUZ.Core.Creator.Meshes.V2.Builder
 
         protected void BuildViaMrm()
         {
-            MeshFilter meshFilter = RootGo.AddComponent<MeshFilter>();
-            MeshRenderer meshRenderer = RootGo.AddComponent<MeshRenderer>();
+            MeshFilter meshFilter = RootGo.TryAddComponent<MeshFilter>();
+            MeshRenderer meshRenderer = RootGo.TryAddComponent<MeshRenderer>();
             meshRenderer.material = Constants.LoadingMaterial;
             PrepareMeshFilter(meshFilter, Mrm, meshRenderer);
 
@@ -247,8 +247,8 @@ namespace GUZ.Core.Creator.Meshes.V2.Builder
             foreach (KeyValuePair<string, IMultiResolutionMesh> subMesh in attachments)
             {
                 GameObject meshObj = nodeObjects.First(bone => bone.name == subMesh.Key);
-                MeshFilter meshFilter = meshObj.AddComponent<MeshFilter>();
-                MeshRenderer meshRenderer = meshObj.AddComponent<MeshRenderer>();
+                MeshFilter meshFilter = meshObj.TryAddComponent<MeshFilter>();
+                MeshRenderer meshRenderer = meshObj.TryAddComponent<MeshRenderer>();
                 meshRenderer.material = Constants.LoadingMaterial;
 
                 PrepareMeshFilter(meshFilter, subMesh.Value, meshRenderer);
@@ -271,8 +271,8 @@ namespace GUZ.Core.Creator.Meshes.V2.Builder
 
         protected GameObject BuildViaMmb()
         {
-            var meshFilter = RootGo.AddComponent<MeshFilter>();
-            var meshRenderer = RootGo.AddComponent<MeshRenderer>();
+            var meshFilter = RootGo.TryAddComponent<MeshFilter>();
+            var meshRenderer = RootGo.TryAddComponent<MeshRenderer>();
             
             PrepareMeshFilter(meshFilter, Mmb.Mesh, meshRenderer);
             PrepareMeshRenderer(meshRenderer, Mmb.Mesh);
@@ -536,7 +536,7 @@ namespace GUZ.Core.Creator.Meshes.V2.Builder
 
         protected Collider PrepareMeshCollider(GameObject obj, Mesh mesh)
         {
-            var meshCollider = obj.AddComponent<MeshCollider>();
+            var meshCollider = obj.TryAddComponent<MeshCollider>();
             meshCollider.sharedMesh = mesh;
             return meshCollider;
         }

--- a/Assets/Gothic-UnZENity-Core/Scripts/Creator/Meshes/V2/Builder/AbstractMeshBuilder.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Creator/Meshes/V2/Builder/AbstractMeshBuilder.cs
@@ -1,8 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using GUZ.Core.Caches;
-using GUZ.Core.Globals;
 using GUZ.Core.Extensions;
+using GUZ.Core.Globals;
 using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -180,22 +181,23 @@ namespace GUZ.Core.Creator.Meshes.V2.Builder
                 for (var i = 0; i < Mdh.Nodes.Count; i++)
                 {
                     var node = Mdh.Nodes[i];
-                    // We attached some Components to root of bones. Therefore reusing it.
-                    if (node.Name.EqualsIgnoreCase("BIP01"))
+                    var nodeName = node.Name;
+
+                    if (TryGetExistingGoInsideNodeHierarchy(Mdh.Nodes, node, out var foundGo))
                     {
-                        var bip01 = RootGo.FindChildRecursively("BIP01");
-                        if (bip01 != null)
-                            nodeObjects[i] = RootGo.FindChildRecursively("BIP01");
-                        else
-                            nodeObjects[i] = new GameObject(Mdh.Nodes[i].Name);
+                        nodeObjects[i] = foundGo;
+                        // Whenever we found a GameObject inside a prefab (pre-existing GameObject),
+                        // we rename it as it could potentially contain a regex based name.
+                        foundGo!.name = nodeName;
                     }
                     else
                     {
-                        nodeObjects[i] = new GameObject(Mdh.Nodes[i].Name);
+                        nodeObjects[i] = new GameObject(node.Name);
                     }
                 }
 
                 // Now set parents
+                // HINT: If we found pre-existing nodes, it might be, that the merge between new nodes and existing GOs will reorder them. No issue found so far.
                 for (var i = 0; i < Mdh.Nodes.Count; i++)
                 {
                     var node = Mdh.Nodes[i];
@@ -267,6 +269,86 @@ namespace GUZ.Core.Creator.Meshes.V2.Builder
             // We need to reset the rootBones position to zero. Otherwise Vobs won't be placed right.
             // Due to Unity's parent-child transformation magic, we need to do it at the end. ╰(*°▽°*)╯
             nodeObjects[0].transform.localPosition = Vector3.zero;
+        }
+
+        /// <summary>
+        /// Check if the current node already exists inside the existing GameObject starting with RootGO.
+        ///
+        /// Lookup order:
+        /// Nodes: from bottom to top, then compared with GOs in reverse order (top to bottom)
+        /// GameObjects: From top to bottom
+        ///
+        /// Example GOs (from a Prefab):
+        /// BIP01
+        ///   |- BIP01 CHEST_.*_1
+        ///
+        /// Example node hierarchy:
+        /// BIP01
+        ///   |- BIP01 CHESTLOCK
+        ///   |- BIP01 CHEST_SMALL_1
+        ///
+        /// Merged GOs:
+        /// BIP01
+        ///   |- BIP01 CHEST_SMALL_1 - from prefab; but the order changed later, when glued together with new GOs. No issue on that so far.
+        ///   |- BIP01 CHESTLOCK     - from nodes; new
+        /// </summary>
+        private bool TryGetExistingGoInsideNodeHierarchy(List<IModelHierarchyNode> nodes, IModelHierarchyNode currentNode, [CanBeNull] out GameObject foundGo)
+        {
+            // We use a stack to have LI-FO approach. When we loop, we need to start from root (last entry), not bottom (first entry).
+            var loopHierarchy = new Stack<IModelHierarchyNode>();
+            loopHierarchy.Push(currentNode);
+
+            // Fetch nodes all the way up.
+            {
+                var walkedNode = currentNode;
+                while (walkedNode.ParentIndex != -1)
+                {
+                    walkedNode = nodes[walkedNode.ParentIndex];
+                    loopHierarchy.Push(walkedNode);
+                }
+            }
+
+            var currentGo = RootGo; // Start from top to bottom
+            var childFound = false;
+
+            // Loop through the nodes from top to bottom and check if there's always a matching GO.
+            while (!loopHierarchy.IsEmpty())
+            {
+                foreach (var childGo in currentGo.GetAllDirectChildren())
+                {
+                    // Fast comparison - If name is already matching NodeName from Gothic data, we are fine.
+                    if (childGo.name.Equals(loopHierarchy.Peek().Name))
+                    {
+                        currentGo = childGo;
+                        childFound = true;
+                        break;
+                    }
+
+                    // Second comparison - We need to check if the name of this GO is matching a regex pattern for NodeName
+                    // e.g. BIP01 CHEST_.*_1 --> matches --> BIP01 CHEST_SMALL_1
+                    var regex = new Regex(childGo.name, RegexOptions.IgnoreCase);
+                    if(regex.IsMatch(loopHierarchy.Peek().Name))
+                    {
+                        currentGo = childGo;
+                        childFound = true;
+                        break;
+                    }
+                }
+
+                // If - at some point - the loop ended
+                if (!childFound)
+                {
+                    foundGo = null;
+                    return false;
+                }
+
+                childFound = false; // We are not done yet and need to check next iteration again.
+                loopHierarchy.Pop();
+            }
+
+            // We looped all the way from root to leaf and every time, we got a matching element from existing GameObjects.
+            foundGo = currentGo;
+            return true;
         }
 
         protected GameObject BuildViaMmb()

--- a/Assets/Gothic-UnZENity-Core/Scripts/Creator/Meshes/V2/Builder/AbstractMeshBuilder.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Creator/Meshes/V2/Builder/AbstractMeshBuilder.cs
@@ -271,86 +271,6 @@ namespace GUZ.Core.Creator.Meshes.V2.Builder
             nodeObjects[0].transform.localPosition = Vector3.zero;
         }
 
-        /// <summary>
-        /// Check if the current node already exists inside the existing GameObject starting with RootGO.
-        ///
-        /// Lookup order:
-        /// Nodes: from bottom to top, then compared with GOs in reverse order (top to bottom)
-        /// GameObjects: From top to bottom
-        ///
-        /// Example GOs (from a Prefab):
-        /// BIP01
-        ///   |- BIP01 CHEST_.*_1
-        ///
-        /// Example node hierarchy:
-        /// BIP01
-        ///   |- BIP01 CHESTLOCK
-        ///   |- BIP01 CHEST_SMALL_1
-        ///
-        /// Merged GOs:
-        /// BIP01
-        ///   |- BIP01 CHEST_SMALL_1 - from prefab; but the order changed later, when glued together with new GOs. No issue on that so far.
-        ///   |- BIP01 CHESTLOCK     - from nodes; new
-        /// </summary>
-        private bool TryGetExistingGoInsideNodeHierarchy(List<IModelHierarchyNode> nodes, IModelHierarchyNode currentNode, [CanBeNull] out GameObject foundGo)
-        {
-            // We use a stack to have LI-FO approach. When we loop, we need to start from root (last entry), not bottom (first entry).
-            var loopHierarchy = new Stack<IModelHierarchyNode>();
-            loopHierarchy.Push(currentNode);
-
-            // Fetch nodes all the way up.
-            {
-                var walkedNode = currentNode;
-                while (walkedNode.ParentIndex != -1)
-                {
-                    walkedNode = nodes[walkedNode.ParentIndex];
-                    loopHierarchy.Push(walkedNode);
-                }
-            }
-
-            var currentGo = RootGo; // Start from top to bottom
-            var childFound = false;
-
-            // Loop through the nodes from top to bottom and check if there's always a matching GO.
-            while (!loopHierarchy.IsEmpty())
-            {
-                foreach (var childGo in currentGo.GetAllDirectChildren())
-                {
-                    // Fast comparison - If name is already matching NodeName from Gothic data, we are fine.
-                    if (childGo.name.Equals(loopHierarchy.Peek().Name))
-                    {
-                        currentGo = childGo;
-                        childFound = true;
-                        break;
-                    }
-
-                    // Second comparison - We need to check if the name of this GO is matching a regex pattern for NodeName
-                    // e.g. BIP01 CHEST_.*_1 --> matches --> BIP01 CHEST_SMALL_1
-                    var regex = new Regex(childGo.name, RegexOptions.IgnoreCase);
-                    if(regex.IsMatch(loopHierarchy.Peek().Name))
-                    {
-                        currentGo = childGo;
-                        childFound = true;
-                        break;
-                    }
-                }
-
-                // If - at some point - the loop ended
-                if (!childFound)
-                {
-                    foundGo = null;
-                    return false;
-                }
-
-                childFound = false; // We are not done yet and need to check next iteration again.
-                loopHierarchy.Pop();
-            }
-
-            // We looped all the way from root to leaf and every time, we got a matching element from existing GameObjects.
-            foundGo = currentGo;
-            return true;
-        }
-
         protected GameObject BuildViaMmb()
         {
             var meshFilter = RootGo.TryAddComponent<MeshFilter>();
@@ -733,6 +653,86 @@ namespace GUZ.Core.Creator.Meshes.V2.Builder
         protected void SetPosAndRot(GameObject obj, Vector3 position, Quaternion rotation)
         {
             obj.transform.SetLocalPositionAndRotation(position, rotation);
+        }
+
+        /// <summary>
+        /// Check if the current node already exists inside the existing GameObject starting with RootGO.
+        ///
+        /// Lookup order:
+        /// Nodes: from bottom to top, then compared with GOs in reverse order (top to bottom)
+        /// GameObjects: From top to bottom
+        ///
+        /// Example GOs (from a Prefab):
+        /// BIP01
+        ///   |- BIP01 CHEST_.*_1
+        ///
+        /// Example node hierarchy:
+        /// BIP01
+        ///   |- BIP01 CHESTLOCK
+        ///   |- BIP01 CHEST_SMALL_1
+        ///
+        /// Merged GOs:
+        /// BIP01
+        ///   |- BIP01 CHEST_SMALL_1 - from prefab; but the order changed later, when glued together with new GOs. No issue on that so far.
+        ///   |- BIP01 CHESTLOCK     - from nodes; new
+        /// </summary>
+        private bool TryGetExistingGoInsideNodeHierarchy(List<IModelHierarchyNode> nodes, IModelHierarchyNode currentNode, [CanBeNull] out GameObject foundGo)
+        {
+            // We use a stack to have LI-FO approach. When we loop, we need to start from root (last entry), not bottom (first entry).
+            var loopHierarchy = new Stack<IModelHierarchyNode>();
+            loopHierarchy.Push(currentNode);
+
+            // Fetch nodes all the way up.
+            {
+                var walkedNode = currentNode;
+                while (walkedNode.ParentIndex != -1)
+                {
+                    walkedNode = nodes[walkedNode.ParentIndex];
+                    loopHierarchy.Push(walkedNode);
+                }
+            }
+
+            var currentGo = RootGo; // Start from top to bottom
+            var childFound = false;
+
+            // Loop through the nodes from top to bottom and check if there's always a matching GO.
+            while (!loopHierarchy.IsEmpty())
+            {
+                foreach (var childGo in currentGo.GetAllDirectChildren())
+                {
+                    // Fast comparison - If name is already matching NodeName from Gothic data, we are fine.
+                    if (childGo.name.Equals(loopHierarchy.Peek().Name))
+                    {
+                        currentGo = childGo;
+                        childFound = true;
+                        break;
+                    }
+
+                    // Second comparison - We need to check if the name of this GO is matching a regex pattern for NodeName
+                    // e.g. BIP01 CHEST_.*_1 --> matches --> BIP01 CHEST_SMALL_1
+                    var regex = new Regex(childGo.name, RegexOptions.IgnoreCase);
+                    if(regex.IsMatch(loopHierarchy.Peek().Name))
+                    {
+                        currentGo = childGo;
+                        childFound = true;
+                        break;
+                    }
+                }
+
+                // If - at some point - the loop ended
+                if (!childFound)
+                {
+                    foundGo = null;
+                    return false;
+                }
+
+                childFound = false; // We are not done yet and need to check next iteration again.
+                loopHierarchy.Pop();
+            }
+
+            // We looped all the way from root to leaf and every time, we got a matching element from existing GameObjects.
+            foundGo = currentGo;
+            return true;
         }
     }
 }

--- a/Assets/Gothic-UnZENity-Core/Scripts/Creator/VobCreator.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Creator/VobCreator.cs
@@ -406,6 +406,9 @@ namespace GUZ.Core.Creator
                 case VirtualObjectType.oCMobContainer:
                     go = PrefabCache.TryGetObject(PrefabCache.PrefabType.VobContainer);
                     break;
+                case VirtualObjectType.oCMobLadder:
+                    go = PrefabCache.TryGetObject(PrefabCache.PrefabType.VobLadder);
+                    break;
                 case VirtualObjectType.zCVobAnimate:
                     go = PrefabCache.TryGetObject(PrefabCache.PrefabType.VobAnimate);
                     break;

--- a/Assets/Gothic-UnZENity-Core/Scripts/Extensions/GameObjectExtension.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Extensions/GameObjectExtension.cs
@@ -50,6 +50,16 @@ namespace GUZ.Core.Extensions
                 .Select(i => go.transform.GetChild(i).gameObject)
                 .ToArray();
         }
-        
+
+        /// <summary>
+        /// Either add or get existing component on GameObject.
+        /// </summary>
+        public static T TryAddComponent<T>(this GameObject go) where T : Component
+        {
+            if (go.TryGetComponent<T>(out var component))
+                return component;
+            else
+                return go.AddComponent<T>();
+        }
     }
 }

--- a/Assets/Gothic-UnZENity-Lab/Scripts/Handler/LabLadderHandler.cs
+++ b/Assets/Gothic-UnZENity-Lab/Scripts/Handler/LabLadderHandler.cs
@@ -12,11 +12,12 @@ namespace GUZ.Lab.Handler
 
         public void Bootstrap()
         {
+            var itemPrefab = PrefabCache.TryGetObject(PrefabCache.PrefabType.Ladder);
             var ladderName = "LADDER_3.MDL";
             var mdl = AssetCache.TryGetMdl(ladderName);
 
             var vobObj = MeshFactory.CreateVob(ladderName, mdl, Vector3.zero, Quaternion.Euler(0, 270, 0),
-                ladderSlot, useTextureArray: false);
+                ladderSlot, rootGo: itemPrefab, useTextureArray: false);
 
 
             // Data taken from VobCreator.CreateLadder()

--- a/Docs/development/developer-hints.md
+++ b/Docs/development/developer-hints.md
@@ -84,3 +84,27 @@ We work with async-await for scene loading. It provides us a way to skip frames 
 Hint: async is _*not!*_ async as another thread. The way we use it, it's nearly the same as Coroutine. i.e. we just define synchronously when to skip to the next frame.
 
 ![SceneLoading](./diagrams/SceneLoading.drawio.png)
+
+
+## Prefab usage
+We load all Gothic assets at runtime. Nevertheless, Prefabs can come in handy at some times.
+Therefore, we implemented a logic to merge GameObject structure including their components via Regex.
+Especially used for Vobs.
+
+Example for merging GameObjects from source code documentation at
+_AbstractMeshBuilder.TryGetExistingGoInsideNodeHierarchy()_
+```c#
+/// Example GOs (from a Prefab):
+/// BIP01
+///   |- BIP01 CHEST_.*_1
+
+/// Example node hierarchy:
+/// BIP01
+///   |- BIP01 CHESTLOCK
+///   |- BIP01 CHEST_SMALL_1
+
+/// Merged GOs:
+/// BIP01
+///   |- BIP01 CHEST_SMALL_1 - from prefab; but the order changed later, when glued together with new GOs. No issue on that so far.
+///   |- BIP01 CHESTLOCK     - from nodes; new
+```


### PR DESCRIPTION
Prefabs will now be used in combination with loading objects by merging via regex. Example inside README:

## Prefab usage
We load all Gothic assets at runtime. Nevertheless, Prefabs can come in handy at some times.
Therefore, we implemented a logic to merge GameObject structure including their components via Regex.
Especially used for Vobs.

Example for merging GameObjects from source code documentation at
_AbstractMeshBuilder.TryGetExistingGoInsideNodeHierarchy()_
```c#
/// Example GOs (from a Prefab):
/// BIP01
///   |- BIP01 CHEST_.*_1
/// Example node hierarchy:
/// BIP01
///   |- BIP01 CHESTLOCK
///   |- BIP01 CHEST_SMALL_1
/// Merged GOs:
/// BIP01
///   |- BIP01 CHEST_SMALL_1 - from prefab; but the order changed later, when glued together with new GOs. No issue on that so far.
///   |- BIP01 CHESTLOCK     - from nodes; new
```