### PR TITLE
Feature/27 coding standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,42 @@
+[*]
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+# For more details on C# code formatting, please visit our style-guide example: https://github.com/Gothic-UnZENity-Project/Gothic-UnZENity/blob/main/Docs/development/style-guide.md
+# Rider - Auto-apply of settings during save: https://www.jetbrains.com/help/resharper/Enforcing_Code_Formatting_Rules.html#run-code-cleanup-automatically-on-save
+# VS22  - Auto-apply of settings during save: https://devblogs.microsoft.com/visualstudio/bringing-code-cleanup-on-save-to-visual-studio-2022-17-1-preview-2/
+
+[*.cs]
+# Allow var. e.g. var isEnabled = true;
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Define private members/static variables to be underscored: e.g. private bool _isEnabled;
+# Hint: Constants are also handled by it.
+dotnet_naming_rule.private_members_with_underscore.symbols  = private_fields
+dotnet_naming_rule.private_members_with_underscore.style    = prefix_underscore
+dotnet_naming_rule.private_members_with_underscore.severity = warning
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_style.prefix_underscore.capitalization  = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
+
+# Define protected/public fields to be PascalCase: e.g. protected bool IsEnabled;
+dotnet_naming_rule.public_fields.symbols  = public_fields
+dotnet_naming_rule.public_fields.style    = pascal_case
+dotnet_naming_rule.public_fields.severity = warning
+dotnet_naming_symbols.public_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = protected, public
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+# Braces around single IF statements.
+csharp_prefer_braces = true:warning
+
+
+[{*.json,*.yaml,*.yml}]
+indent_style = space
+indent_size = 2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,9 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
 (People *love* thorough bug reports. I'm not even kidding.)
 
 ### Use a Consistent Coding Style
-Easiest way is to check on some sample classes and reuse their style.
+To assist consistent development styles, we:
+1. set up an .editorconfig file which is automatically used by Rider and VS22+
+2. wrote an exhaustive example at our docs: [Style-Guide.md](./Docs/development/style-guide.md)
 
 ### License
 By contributing, you agree that your contributions will be licensed under its GPL-3.0 License.

--- a/Docs/development/style-guide.md
+++ b/Docs/development/style-guide.md
@@ -1,0 +1,270 @@
+```c#
+// STYLE SHEET EXAMPLE
+// Taken and slighly altered from Thomas Krogh-Jacobsen (Team lead, Tech Content Marketing Management at Unity Technologies)
+// @see: https://github.com/thomasjacobsen-unity/Unity-Code-Style-Guide/blob/master/StyleExample.cs
+
+//-------------------------
+
+// NAMING/CASING:
+// - Use Pascal case (e.g. ExamplePlayerController, MaxHealth, etc.) unless noted otherwise
+// - Use camel case (e.g. examplePlayerController, maxHealth, etc.) for local variables, parameters.
+// - Avoid snake case, kebab case, Hungarian notation
+// - The source file name must match. 
+
+// FORMATTING:
+// - Use Allman (opening curly braces on a new line).
+// - Keep lines short. Consider horizontal whitespace. Use a standard line width in your style guide 120 characters. 
+// - Use a single space before flow control conditions, e.g. while (x == y)
+// - Avoid spaces inside brackets, e.g. x = dataArray[index]
+// - Use a single space after a comma between function arguments.
+// - Don’t add a space after the parenthesis and function arguments, e.g. CollectItem(myObject, 0, 1);
+// - Don’t use spaces between a function name and parenthesis, e.g. DropPowerUp(myPrefab, 0, 1);
+// - Use vertical spacing (extra blank line) for visual separation. 
+
+// COMMENTS:
+// - Rather than simply answering "what" or "how," comments can fill in the gaps and tell us "why."
+// - Use the // comment to keep the explanation next to the logic.
+// - Use a Tooltip instead of a comment for serialized fields. 
+// - Avoid Regions. They encourage large class sizes. Collapsed code is more difficult to read. 
+// - Use a summary XML tag in front of public methods or functions for output documentation/Intellisense.
+
+
+// USING LINES:
+// - Keep using lines at the top of your file.
+// - Remove unsed lines.
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+
+// NAMESPACES:
+// - Pascal case, without special symbols or underscores.
+// - Add using line at the top to avoid typing namespace repeatedly.
+// - Create sub-namespaces with the dot (.) operator, e.g. MyApplication.GameFlow, MyApplication.AI, etc.
+namespace StyleSheetExample
+{
+
+    // ENUMS:
+    // - Use a singular type name.
+    // - No prefix or suffix.
+    public enum Direction
+    {
+        North,
+        South,
+        East,
+        West,
+    }
+
+    // FLAGS ENUMS:
+    // - Use a plural type name 
+    // - No prefix or suffix.
+    // - Use column-alignment for binary values
+    [Flags]
+    public enum AttackModes
+    {
+        // Decimal                         // Binary
+        None = 0,                          // 000000
+        Melee = 1,                         // 000001
+        Ranged = 2,                        // 000010
+        Special = 4,                       // 000100
+
+        MeleeAndSpecial = Melee | Special  // 000101
+    }
+
+    // INTERFACES:
+    // - Name interfaces with adjective phrases.
+    // - Use the 'I' prefix.
+    public interface IDamageable
+    {
+        string DamageTypeName { get; }
+        float DamageValue { get; }
+
+        // METHODS:
+        // - Start a methods name with a verbs or verb phrases to show an action.
+        // - Parameter names are camelCase.
+        bool ApplyDamage(string description, float damage, int numberOfHits);
+    }
+
+    public interface IDamageable<T>
+    {
+        void Damage(T damageTaken);
+    }
+
+    // CLASSES or STRUCTS:
+    // - Name them with nouns or noun phrases.
+    // - Avoid prefixes.
+    // - One Class/Interface per file. The source file name must match. 
+    public class StyleExample : MonoBehaviour
+    {
+
+        // FIELDS: 
+        // - Avoid special characters (backslashes, symbols, Unicode characters); these can interfere with command line tools.
+        // - Use nouns for names, but prefix booleans with a verb.
+        // - Use meaningful names. Make names searchable and pronounceable. Don’t abbreviate (unless it’s math).
+        // - Use Pascal case for public fields. Use camel case for private variables.
+        // - Add an underscore (_) in front of private fields to differentiate from local variables
+        private int _elapsedTimeInDays;
+
+        // Use [SerializeField] attribute if you want to display a private field in Inspector.
+        // Booleans ask a question that can be answered true or false.
+        [SerializeField] private bool _isPlayerDead;
+
+        // This groups data from the custom PlayerStats class in the Inspector.
+        [SerializeField] private PlayerStats _stats;
+
+        // This limits the values to a Range and creates a slider in the Inspector.
+        [Range(0f, 1f)] [SerializeField] private float _rangedStat;
+
+        // A tooltip can replace a comment on a serialized field and do double duty.
+        [Tooltip("This is another statistic for the player.")]
+        [SerializeField] private float _anotherStat;
+
+
+        // PROPERTIES:
+        // - Preferable to a public field.
+        // - Pascal case, without special characters.
+        // - Use the expression-bodied properties to shorten, but choose your preferred format.
+        // - e.g. use expression-bodied for read-only properties but { get; set; } for everything else.
+        // - Use the Auto-Implemented Property for a public property without a backing field.
+
+        // the private backing field
+        private int _maxHealth;
+
+        // read-only, returns backing field
+        public int MaxHealthReadOnly => _maxHealth;
+
+        // equivalent to:
+        // public int MaxHealth { get; private set; }
+
+        // explicitly implementing getter and setter
+        public int MaxHealth
+        {
+            get => _maxHealth;
+            set => _maxHealth = value;
+        }
+
+        // write-only (not using backing field)
+        public int Health { private get; set; }
+
+        // write-only, without an explicit setter
+        public void SetMaxHealth(int newMaxValue) => _maxHealth = newMaxValue;
+
+        // auto-implemented property without backing field
+        public string DescriptionName { get; set; } = "Fireball";
+
+
+        // EVENTS:
+        // - Use C# Events in favor to UnityEvents as the latter is way slower: https://www.jacksondunstan.com/articles/3335
+        // - Name with a verb phrase.
+        // - Present participle means "before" and past participle mean "after."
+        // - Use System.Action delegate for most events (can take 0 to 16 parameters).
+        // - Define a custom EventArg only if necessary (either System.EventArgs or a custom struct).
+        // - OR alternatively, use the System.EventHandler; choose one and apply consistently.
+        // - Choose a naming scheme for events, event handling methods (subscriber/observer), and event raising methods (publisher/subject)
+        // - e.g. event/action = "OpeningDoor", event raising method = "OnDoorOpened", event handling method = "MySubject_DoorOpened"
+                
+        // event before
+        public event UnityEvent OpeningDoor;
+
+        // event after
+        public event UnityEvent DoorOpened;     
+
+        public event Action<int> PointsScored;
+        public event Action<CustomEventArgs> ThingHappened;
+
+        // These are event raising methods, e.g. OnDoorOpened, OnPointsScored, etc.
+        public void OnDoorOpened()
+        {
+            DoorOpened?.Invoke();
+        }
+
+        public void OnPointsScored(int points)
+        {
+            PointsScored?.Invoke(points);
+        }
+
+        // This is a custom EventArg made from a struct.
+        public struct CustomEventArgs
+        {
+            public int ObjectID { get; }
+            public Color Color { get; }
+
+            public CustomEventArgs(int objectId, Color color)
+            {
+                this.ObjectID = objectId;
+                this.Color = color;
+            }
+        }
+
+
+        // METHODS:
+        // - Start a method name with verbs or verb phrases to show an action.
+        // - Parameter names are camel case.
+
+        // Methods start with a verb.
+        public void SetInitialPosition(float x, float y, float z)
+        {
+            transform.position = new Vector3(x, y, z);
+        }
+
+        // Methods ask a question when they return bool.
+        public bool IsNewPosition(Vector3 newPosition)
+        {
+            return (transform.position == newPosition);
+        }
+
+        private void FormatExamples(int someExpression)
+        {
+            // VAR:
+            // - Use var if it helps readability, especially with long type names.
+            // - Avoid var if it makes the type ambiguous.
+            var powerUps = new List<PlayerStats>();
+            var dict = new Dictionary<string, List<GameObject>>();
+
+
+            // SWITCH STATEMENTS:
+            // - Indent each case and the break underneath.
+            switch (someExpression)
+            {
+                case 0:
+                    // ..
+                    break;
+                case 1:
+                {
+                    // ..
+                    break;
+                }
+            }
+
+            // BRACES: 
+            // - Keep braces for clarity when using single-line statements.
+            // - Or avoid single-line statement entirely for debuggability.
+            // - Keep braces in nested multi-line statements.
+
+            // This single-line statement keeps the braces...
+            for (int i = 0; i < 100; i++) { DoSomething(i); }
+
+            // ... but this is more debuggable. You can set a breakpoint on the clause.
+            for (int i = 0; i < 100; i++)
+            {
+                DoSomething(i);
+            }
+
+            // Don't remove the braces here.
+            for (int i = 0; i < 10; i++)
+            {
+                for (int j = 0; j < 10; j++)
+                {
+                    DoSomething(j);
+                }
+            }
+        }
+
+        private void DoSomething(int x)
+        {
+            // .. 
+        }
+    }
+}
+
+```

--- a/Docs/development/style-guide.md
+++ b/Docs/development/style-guide.md
@@ -1,10 +1,24 @@
+# General
+
+Our Gothic-UnZENity style guide is taken from MS' official C# guide with a few additional changes where useful.
+You will find a full example of it below.
+
+We added a few settings into .editorconfig (e.g. underscore warning for private fields) which is automatically read by Rider and VS.
+It can be updated whenever necessary.
+
+# Auto-apply code formatting during save
+
+Both IDEs, Rider and Visual Studio, support auto formatting based on the settings we have set on .editorconfig.
+They can be applied like this:
+* [Rider](https://www.jetbrains.com/help/resharper/Enforcing_Code_Formatting_Rules.html#run-code-cleanup-automatically-on-save)
+* [VS22](https://devblogs.microsoft.com/visualstudio/bringing-code-cleanup-on-save-to-visual-studio-2022-17-1-preview-2/)
+
+# Specific example
+Taken and slightly altered from Thomas Krogh-Jacobsen (Team lead, Tech Content Marketing Management at Unity Technologies).  
+@see: https://github.com/thomasjacobsen-unity/Unity-Code-Style-Guide/blob/master/StyleExample.cs
+
+
 ```c#
-// STYLE SHEET EXAMPLE
-// Taken and slighly altered from Thomas Krogh-Jacobsen (Team lead, Tech Content Marketing Management at Unity Technologies)
-// @see: https://github.com/thomasjacobsen-unity/Unity-Code-Style-Guide/blob/master/StyleExample.cs
-
-//-------------------------
-
 // NAMING/CASING:
 // - Use Pascal case (e.g. ExamplePlayerController, MaxHealth, etc.) unless noted otherwise
 // - Use camel case (e.g. examplePlayerController, maxHealth, etc.) for local variables, parameters.
@@ -103,7 +117,9 @@ namespace StyleSheetExample
         // - Use meaningful names. Make names searchable and pronounceable. Don’t abbreviate (unless it’s math).
         // - Use Pascal case for public fields. Use camel case for private variables.
         // - Add an underscore (_) in front of private fields to differentiate from local variables
+        // - Constants are also just plain fields without special naming (underscore when private, camel case when public).
         private int _elapsedTimeInDays;
+        private const int _hoursPerDay = 24;
 
         // Use [SerializeField] attribute if you want to display a private field in Inspector.
         // Booleans ask a question that can be answered true or false.

--- a/Docs/development/style-guide.md
+++ b/Docs/development/style-guide.md
@@ -122,6 +122,7 @@ namespace StyleSheetExample
         private const int _hoursPerDay = 24;
 
         // Use [SerializeField] attribute if you want to display a private field in Inspector.
+        // Try to use private Fields for Components/MonoBehaviours, if you don't need them to be public.
         // Booleans ask a question that can be answered true or false.
         [SerializeField] private bool _isPlayerDead;
 


### PR DESCRIPTION
# Please review briefly:

* Start Rider and check if the following lines will hint a yellow warning:
* (optional) Test the same warnings with VS22
---
- [ ] 1. ```private bool isTest;``` <-- Needs to be underscored
![image](https://github.com/Gothic-UnZENity-Project/Gothic-UnZENity/assets/120568393/83736bd0-ce5b-4a5e-9c27-74e5a8339ffc)
---
- [ ] 2. ```protected bool isTest2;``` <-- Needs to be PascalCase like every non-private field
![image](https://github.com/Gothic-UnZENity-Project/Gothic-UnZENity/assets/120568393/da8fe2f2-ebbf-4604-99cd-e040f5532afd)
---
- [ ] 3. Braces are needed.
```c#
if (isActiveAndEnabled)
    return;
```
![image](https://github.com/Gothic-UnZENity-Project/Gothic-UnZENity/assets/120568393/1e9132ff-0bb4-4778-abe4-3bf44744c710)
![image](https://github.com/Gothic-UnZENity-Project/Gothic-UnZENity/assets/120568393/20795789-5b2a-461e-876a-2c5670423939)

---
# Out-of-scope:
* I added only ~5 checks. Please look at .editorconfig for details. We can update in the future whenever needed.
* I only linked to "auto-format on save" documentation. I think this is sufficient.
