### PR TITLE
Feature/64 add conditional showhide of inspector properties

### DIFF
--- a/Assets/Gothic-UnZENity-Core/Editor/Scripts/Tools/ContextTool.cs
+++ b/Assets/Gothic-UnZENity-Core/Editor/Scripts/Tools/ContextTool.cs
@@ -19,7 +19,7 @@ namespace GUZ.Core.Editor.Tools
             var hvrCompilerSettingExists = PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.Standalone)
                 .Contains(HVR_COMPILER_FLAG);
             var hvrSceneSetting = Object.FindObjectOfType<GameManager>()?.Config.GameControls ==
-                                  GuzContext.Controls.VRHvr;
+                                  GuzContext.Controls.HVR;
 
             var message =
                 $"Plugin installed: {hvrExists}\n" +

--- a/Assets/Gothic-UnZENity-Core/Resources/GameConfigurations/Production.asset
+++ b/Assets/Gothic-UnZENity-Core/Resources/GameConfigurations/Production.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 355b4ad0092f448a80ea647207f12648, type: 3}
   m_Name: Production
   m_EditorClassIdentifier: 
-  EnableDeviceSimulator: 0
   GameControls: 0
+  EnableDeviceSimulator: 0
   EnableMainMenu: 1
   LoadFromSaveSlot: 0
   SaveSlotToLoad: 1

--- a/Assets/Gothic-UnZENity-Core/Resources/GameConfigurations/Production.asset
+++ b/Assets/Gothic-UnZENity-Core/Resources/GameConfigurations/Production.asset
@@ -53,6 +53,6 @@ MonoBehaviour:
     MaximumObjectSize: 100
     CullingDistance: 200
   ZenkitLogLevel: 1
+  EnableSpyLogs: 0
   DirectMusicLogLevel: 30
   EnableBarrierLogs: 0
-  EnableSpyLogs: 0

--- a/Assets/Gothic-UnZENity-Core/Resources/GameConfigurations/Production.asset
+++ b/Assets/Gothic-UnZENity-Core/Resources/GameConfigurations/Production.asset
@@ -22,16 +22,31 @@ MonoBehaviour:
   LoadFromSaveSlot: 0
   SaveSlotToLoad: 0
   EnableVOBs: 1
-  SpawnVOBTypes: 
-  SpawnOldCampNpcs: 0
-  EnableNpcRoutines: 0
-  SpawnNpcInstances: 
+  SpawnVOBTypes:
+    Value: 
+  EnableVOBMeshCulling: 1
+  SmallVOBMeshCullingGroup:
+    MaximumObjectSize: 0.2
+    CullingDistance: 50
+  MediumVOBMeshCullingGroup:
+    MaximumObjectSize: 5
+    CullingDistance: 100
+  LargeVOBMeshCullingGroup:
+    MaximumObjectSize: 100
+    CullingDistance: 200
+  ShowVOBMeshCullingGizmos: 0
+  SpawnNPCs: 0
+  EnableNPCRoutines: 0
+  SpawnNPCInstances:
+    Value: 
+  EnableNPCEyeBlinking: 0
   ShowFreePoints: 0
   ShowWayPoints: 0
   ShowWayEdges: 0
   SpawnAtWaypoint: 
   EnableGameMusic: 1
   EnableGameSounds: 1
+  EnableSoundCulling: 1
   SunLightColor: {r: 0.69, g: 0.69, b: 0.69, a: 1}
   SunLightIntensity: 1
   SunUpdateInterval: 1
@@ -39,20 +54,7 @@ MonoBehaviour:
   StartTimeHour: 8
   StartTimeMinute: 0
   TimeSpeedMultiplier: 1
-  SmallMeshCullingGroup:
-    MaximumObjectSize: 0.2
-    CullingDistance: 50
-  MediumMeshCullingGroup:
-    MaximumObjectSize: 5
-    CullingDistance: 100
-  LargeMeshCullingGroup:
-    MaximumObjectSize: 100
-    CullingDistance: 200
-  EnableSoundCulling: 1
-  EnableMeshCulling: 1
-  ShowMeshCullingGizmos: 0
   EnableWorldMesh: 1
   EnableBarrierVisual: 1
   EnableDecalVisuals: 0
   EnableParticleEffects: 0
-  EnableNpcEyeBlinking: 0

--- a/Assets/Gothic-UnZENity-Core/Resources/GameConfigurations/Production.asset
+++ b/Assets/Gothic-UnZENity-Core/Resources/GameConfigurations/Production.asset
@@ -14,37 +14,33 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   GameControls: 0
   EnableDeviceSimulator: 0
+  ZenKitLogLevel: 1
+  EnableZSpyLogs: 0
+  DirectMusicLogLevel: 30
+  EnableBarrierLogs: 0
   EnableMainMenu: 1
   LoadFromSaveSlot: 0
-  SaveSlotToLoad: 1
+  SaveSlotToLoad: 0
+  EnableVOBs: 1
+  SpawnVOBTypes: 
   SpawnOldCampNpcs: 0
   EnableNpcRoutines: 0
-  SpawnAtWaypoint: 
-  EnableWorldObjects: 1
-  EnableWorldMesh: 1
-  EnableBarrierVisual: 1
-  EnableDecalVisuals: 0
-  EnableParticleEffects: 0
-  EnableNpcEyeBlinking: 0
-  SpawnWorldObjectTypes: 
   SpawnNpcInstances: 
-  EnableGameMusic: 1
-  EnableGameSounds: 1
-  SunLightColor: {r: 0.6901961, g: 0.6901961, b: 0.6901961, a: 1}
-  SunLightIntensity: 1
-  SunUpdateInterval: 2
-  AmbientLightColor: {r: 0.10196079, g: 0.10196079, b: 0.10196079, a: 1}
-  StartTimeHour: 8
-  StartTimeMinute: 0
-  TimeSpeedMultiplier: 1
   ShowFreePoints: 0
   ShowWayPoints: 0
   ShowWayEdges: 0
-  EnableSoundCulling: 1
-  EnableMeshCulling: 1
-  ShowMeshCullingGizmos: 0
+  SpawnAtWaypoint: 
+  EnableGameMusic: 1
+  EnableGameSounds: 1
+  SunLightColor: {r: 0.69, g: 0.69, b: 0.69, a: 1}
+  SunLightIntensity: 1
+  SunUpdateInterval: 1
+  AmbientLightColor: {r: 0.1, g: 0.1, b: 0.1, a: 1}
+  StartTimeHour: 8
+  StartTimeMinute: 0
+  TimeSpeedMultiplier: 1
   SmallMeshCullingGroup:
-    MaximumObjectSize: 1
+    MaximumObjectSize: 0.2
     CullingDistance: 50
   MediumMeshCullingGroup:
     MaximumObjectSize: 5
@@ -52,7 +48,11 @@ MonoBehaviour:
   LargeMeshCullingGroup:
     MaximumObjectSize: 100
     CullingDistance: 200
-  ZenkitLogLevel: 1
-  EnableSpyLogs: 0
-  DirectMusicLogLevel: 30
-  EnableBarrierLogs: 0
+  EnableSoundCulling: 1
+  EnableMeshCulling: 1
+  ShowMeshCullingGizmos: 0
+  EnableWorldMesh: 1
+  EnableBarrierVisual: 1
+  EnableDecalVisuals: 0
+  EnableParticleEffects: 0
+  EnableNpcEyeBlinking: 0

--- a/Assets/Gothic-UnZENity-Core/Scripts/Context/GUZContext.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Context/GUZContext.cs
@@ -13,32 +13,32 @@ namespace GUZ.Core.Context
 
         public enum Controls
         {
-            VRXrit, // XR Interaction Toolkit
-            VRHvr // Hurricane VR
+            HVR, // Hurricane VR
+            XRIT // XR Interaction Toolkit
         }
 
         public static void SetContext(Controls controls)
         {
             switch (controls)
             {
-                case Controls.VRXrit:
-                    SetXritContext();
+                case Controls.XRIT:
+                    SetXRITContext();
                     break;
-                case Controls.VRHvr:
-                    SetHvrContext();
+                case Controls.HVR:
+                    SetHVRContext();
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(controls), controls, null);
             }
         }
 
-        private static void SetXritContext()
+        private static void SetXRITContext()
         {
             Debug.Log("Selecting Context: VR - XR Interaction Toolkit (XRIT)");
             InteractionAdapter = new XritInteractionAdapter();
         }
 
-        private static void SetHvrContext()
+        private static void SetHVRContext()
         {
 #if GUZ_HVR_INSTALLED
             Debug.Log("Selecting Context: VR - HurricaneVR");

--- a/Assets/Gothic-UnZENity-Core/Scripts/Creator/NpcCreator.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Creator/NpcCreator.cs
@@ -101,8 +101,8 @@ namespace GUZ.Core.Creator
                 props.Copy(origProps);
             }
 
-            if (GameGlobals.Config.SpawnNpcInstances.Any() &&
-                !GameGlobals.Config.SpawnNpcInstances.Contains(props.NpcInstance.Id))
+            if (GameGlobals.Config.SpawnNPCInstances.Value.Any() &&
+                !GameGlobals.Config.SpawnNPCInstances.Value.Contains(props.NpcInstance.Id))
             {
                 LookupCache.NpcCache.Remove(props.NpcInstance.Index);
                 Object.Destroy(newNpc);
@@ -132,7 +132,7 @@ namespace GUZ.Core.Creator
             WayNetPoint initialSpawnPoint;
 
             // Find the right spawn point based on currently active routine.
-            if (npcGo.GetComponent<Routine>().Routines.Any() && GameGlobals.Config.EnableNpcRoutines)
+            if (npcGo.GetComponent<Routine>().Routines.Any() && GameGlobals.Config.EnableNPCRoutines)
             {
                 var routineSpawnPointName = npcGo.GetComponent<Routine>().CurrentRoutine.Waypoint;
                 initialSpawnPoint = WayNetHelper.GetWayNetPoint(routineSpawnPointName);

--- a/Assets/Gothic-UnZENity-Core/Scripts/Creator/VobCreator.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Creator/VobCreator.cs
@@ -124,7 +124,7 @@ namespace GUZ.Core.Creator
                 GameObject go = null;
 
                 // Debug - Skip loading if not wanted.
-                if (config.SpawnWorldObjectTypes.IsEmpty() || config.SpawnWorldObjectTypes.Contains(vob.Type))
+                if (config.SpawnVOBTypes.IsEmpty() || config.SpawnVOBTypes.Contains(vob.Type))
                 {
                     go = reparent ? LoadVob(config, vob, parent) : LoadVob(config, vob);
                 }

--- a/Assets/Gothic-UnZENity-Core/Scripts/Creator/VobCreator.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Creator/VobCreator.cs
@@ -124,7 +124,7 @@ namespace GUZ.Core.Creator
                 GameObject go = null;
 
                 // Debug - Skip loading if not wanted.
-                if (config.SpawnVOBTypes.IsEmpty() || config.SpawnVOBTypes.Contains(vob.Type))
+                if (config.SpawnVOBTypes.Value.IsEmpty() || config.SpawnVOBTypes.Value.Contains(vob.Type))
                 {
                     go = reparent ? LoadVob(config, vob, parent) : LoadVob(config, vob);
                 }
@@ -293,7 +293,7 @@ namespace GUZ.Core.Creator
                         break;
                     }
 
-                    if (!config.SpawnOldCampNpcs)
+                    if (!config.SpawnNPCs)
                     {
                         break;
                     }

--- a/Assets/Gothic-UnZENity-Core/Scripts/Creator/WorldCreator.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Creator/WorldCreator.cs
@@ -52,8 +52,8 @@ namespace GUZ.Core.Creator
 
             if (config.EnableWorldMesh)
             {
-                var lightingEnabled = config.EnableVOBs && (config.SpawnVOBTypes.IsEmpty() ||
-                                                                    config.SpawnVOBTypes.Contains(
+                var lightingEnabled = config.EnableVOBs && (config.SpawnVOBTypes.Value.IsEmpty() ||
+                                                                    config.SpawnVOBTypes.Value.Contains(
                                                                         VirtualObjectType.zCVobLight));
                 SaveGameManager.CurrentWorldData.SubMeshes = await BuildBspTree(
                     SaveGameManager.CurrentWorldData.Mesh.Cache(),

--- a/Assets/Gothic-UnZENity-Core/Scripts/Creator/WorldCreator.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Creator/WorldCreator.cs
@@ -43,7 +43,7 @@ namespace GUZ.Core.Creator
 
             // Build the world and vob meshes, populating the texture arrays.
             // We need to start creating Vobs as we need to calculate world slicing based on amount of lights at a certain space afterwards.
-            if (config.EnableWorldObjects)
+            if (config.EnableVOBs)
             {
                 await VobCreator.CreateAsync(config, loading, _teleportGo, _nonTeleportGo,
                     SaveGameManager.CurrentWorldData.Vobs, Constants.VObPerFrame);
@@ -52,8 +52,8 @@ namespace GUZ.Core.Creator
 
             if (config.EnableWorldMesh)
             {
-                var lightingEnabled = config.EnableWorldObjects && (config.SpawnWorldObjectTypes.IsEmpty() ||
-                                                                    config.SpawnWorldObjectTypes.Contains(
+                var lightingEnabled = config.EnableVOBs && (config.SpawnVOBTypes.IsEmpty() ||
+                                                                    config.SpawnVOBTypes.Contains(
                                                                         VirtualObjectType.zCVobLight));
                 SaveGameManager.CurrentWorldData.SubMeshes = await BuildBspTree(
                     SaveGameManager.CurrentWorldData.Mesh.Cache(),

--- a/Assets/Gothic-UnZENity-Core/Scripts/GameConfiguration.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/GameConfiguration.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using GUZ.Core.Context;
 using GUZ.Core.World;
 using UnityEngine;
-using UnityEngine.Serialization;
 using ZenKit;
 using ZenKit.Vobs;
 
@@ -12,134 +11,108 @@ namespace GUZ.Core
     [Serializable]
     public class MeshCullingGroup
     {
-        [FormerlySerializedAs("maximumObjectSize")] [Range(1f, 100f)]
+        [Range(1f, 100f)]
         public float MaximumObjectSize;
 
-        [FormerlySerializedAs("cullingDistance")] [Range(1f, 1000f)]
+        [Range(1f, 1000f)]
         public float CullingDistance;
     }
 
     [CreateAssetMenu(fileName = "Data", menuName = "ScriptableObjects/GameConfiguration", order = 1)]
     public class GameConfiguration : ScriptableObject
     {
-        [FormerlySerializedAs("enableDeviceSimulator")] [Header("### Controls ###")]
+        [Header("### Controls ###")]
+        public GuzContext.Controls GameControls = GuzContext.Controls.VRXrit;
+
         public bool EnableDeviceSimulator;
 
-        [FormerlySerializedAs("gameControls")] public GuzContext.Controls GameControls = GuzContext.Controls.VRXrit;
-
-        [FormerlySerializedAs("enableMainMenu")] [Header("### Developer ###")] [SerializeField]
+        [Header("### Developer ###")]
         public bool EnableMainMenu = true;
 
-        [FormerlySerializedAs("loadFromSaveSlot")] [SerializeField]
         public bool LoadFromSaveSlot;
 
-        [FormerlySerializedAs("saveSlotToLoad")] [Range(1, 15)] [SerializeField]
+        [Range(1, 15)]
         public int SaveSlotToLoad;
 
-        [FormerlySerializedAs("spawnOldCampNpcs")] [SerializeField]
         public bool SpawnOldCampNpcs;
 
-        [FormerlySerializedAs("enableNpcRoutines")] [SerializeField]
         public bool EnableNpcRoutines;
 
-        [FormerlySerializedAs("spawnAtWaypoint")] [SerializeField]
         public string SpawnAtWaypoint = string.Empty;
 
-        [FormerlySerializedAs("enableWorldObjects")] [SerializeField]
         public bool EnableWorldObjects = true;
 
-        [FormerlySerializedAs("enableWorldMesh")] [SerializeField]
         public bool EnableWorldMesh = true;
 
-        [FormerlySerializedAs("enableBarrierVisual")] [SerializeField]
         public bool EnableBarrierVisual = true;
 
-        [FormerlySerializedAs("enableDecalVisuals")]
         [InspectorName("Experimental: Enable Decal Visuals")]
-        [SerializeField]
         public bool EnableDecalVisuals;
 
-        [FormerlySerializedAs("enableParticleEffects")]
         [InspectorName("Experimental: Enable Particle Effects")]
-        [SerializeField]
         public bool EnableParticleEffects;
 
-        [FormerlySerializedAs("enableNpcEyeBlinking")] [InspectorName("Experimental: Enable NPC Eye Blinking")]
+        [InspectorName("Experimental: Enable NPC Eye Blinking")]
         public bool EnableNpcEyeBlinking;
 
-        [FormerlySerializedAs("spawnWorldObjectTypes")] [SerializeField]
         public List<VirtualObjectType> SpawnWorldObjectTypes = new();
 
-        [FormerlySerializedAs("spawnNpcInstances")] [SerializeField]
         public List<int> SpawnNpcInstances = new();
 
-        [FormerlySerializedAs("enableGameMusic")] [Header("### Audio ###")] [SerializeField]
+        [Header("### Audio ###")]
         public bool EnableGameMusic = true;
 
-        [FormerlySerializedAs("enableGameSounds")] [SerializeField]
         public bool EnableGameSounds = true;
 
-        [FormerlySerializedAs("sunLightColor")] [Header("### Lighting ###")] [SerializeField]
+        [Header("### Lighting ###")]
         public Color SunLightColor = new(0.6901961f, 0.6901961f, 0.6901961f, 1);
 
-        [FormerlySerializedAs("sunLightIntensity")] [SerializeField] [Range(0, 1)]
+        [Range(0, 1)]
         public float SunLightIntensity = 1;
 
-        [FormerlySerializedAs("sunUpdateInterval")] [SerializeField]
         public GameTimeInterval SunUpdateInterval = GameTimeInterval.EveryGameHour;
 
-        [FormerlySerializedAs("ambientLightColor")] [SerializeField]
         public Color AmbientLightColor = new(0.10196079f, 0.10196079f, 0.10196079f, 1);
 
-        [FormerlySerializedAs("startTimeHour")] [Header("### Time ###")] [SerializeField] [Range(0, 23)]
+        [Header("### Time ###")]
+        [Range(0, 23)]
         public int StartTimeHour = 8;
 
-        [FormerlySerializedAs("startTimeMinute")] [SerializeField] [Range(0, 59)]
+        [Range(0, 59)]
         public int StartTimeMinute;
 
-        [FormerlySerializedAs("timeSpeedMultiplier")] [SerializeField] [Range(0.5f, 1000f)]
+        [Range(0.5f, 1000f)]
         public float TimeSpeedMultiplier = 1;
 
-        [FormerlySerializedAs("showFreePoints")] [Header("### WayNet ###")] [SerializeField]
+        [Header("### WayNet ###")]
         public bool ShowFreePoints;
 
-        [FormerlySerializedAs("showWayPoints")] [SerializeField]
         public bool ShowWayPoints;
 
-        [FormerlySerializedAs("showWayEdges")] [SerializeField]
         public bool ShowWayEdges;
 
-        [FormerlySerializedAs("enableSoundCulling")] [Header("### Culling ###")] [SerializeField]
+        [Header("### Culling ###")]
         public bool EnableSoundCulling = true;
 
-        [FormerlySerializedAs("enableMeshCulling")] [SerializeField]
         public bool EnableMeshCulling = true;
 
-        [FormerlySerializedAs("showMeshCullingGizmos")] [SerializeField]
         public bool ShowMeshCullingGizmos = true;
 
-        [FormerlySerializedAs("smallMeshCullingGroup")] [SerializeField]
         public MeshCullingGroup SmallMeshCullingGroup = new() { MaximumObjectSize = 0.2f, CullingDistance = 50 };
 
-        [FormerlySerializedAs("mediumMeshCullingGroup")] [SerializeField]
         public MeshCullingGroup MediumMeshCullingGroup = new() { MaximumObjectSize = 5.0f, CullingDistance = 100 };
 
-        [FormerlySerializedAs("largeMeshCullingGroup")] [SerializeField]
         public MeshCullingGroup LargeMeshCullingGroup = new() { MaximumObjectSize = 100, CullingDistance = 200 };
 
-        [FormerlySerializedAs("zenkitLogLevel")]
         [Header("### Logging ###")]
         [InspectorName("ZenKit Log Level")]
-        [SerializeField]
         public LogLevel ZenkitLogLevel = LogLevel.Warning;
 
-        [FormerlySerializedAs("directMusicLogLevel")] [InspectorName("DirectMusic Log Level")] [SerializeField]
+        [InspectorName("DirectMusic Log Level")]
         public DirectMusic.LogLevel DirectMusicLogLevel = DirectMusic.LogLevel.Warning;
 
-        [FormerlySerializedAs("enableBarrierLogs")] [SerializeField]
         public bool EnableBarrierLogs;
 
-        [FormerlySerializedAs("enableSpyLogs")] [SerializeField]
         public bool EnableSpyLogs;
     }
 }

--- a/Assets/Gothic-UnZENity-Core/Scripts/GameConfiguration.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/GameConfiguration.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using GUZ.Core.Context;
 using GUZ.Core.World;
+using MyBox;
 using UnityEngine;
 using ZenKit;
 using ZenKit.Vobs;
@@ -21,18 +22,23 @@ namespace GUZ.Core
     [CreateAssetMenu(fileName = "Data", menuName = "ScriptableObjects/GameConfiguration", order = 1)]
     public class GameConfiguration : ScriptableObject
     {
-        [Header("### Controls ###")]
+#region Controls
+        [Foldout("Controls", true)]
         public GuzContext.Controls GameControls = GuzContext.Controls.VRXrit;
 
         public bool EnableDeviceSimulator;
+#endregion
 
-        [Header("### Developer ###")]
+
+#region Developer
+        [Foldout("Developer", true)]
         public bool EnableMainMenu = true;
 
         public bool LoadFromSaveSlot;
 
         [Range(1, 15)]
         public int SaveSlotToLoad;
+        private bool SaveSlotPredicate() => !EnableMainMenu && LoadFromSaveSlot;
 
         public bool SpawnOldCampNpcs;
 
@@ -58,13 +64,19 @@ namespace GUZ.Core
         public List<VirtualObjectType> SpawnWorldObjectTypes = new();
 
         public List<int> SpawnNpcInstances = new();
+#endregion
 
-        [Header("### Audio ###")]
+
+#region Audio
+        [Foldout("Audio", true)]
         public bool EnableGameMusic = true;
 
         public bool EnableGameSounds = true;
+#endregion
 
-        [Header("### Lighting ###")]
+
+#region Lighting
+        [Foldout("Lighting", true)]
         public Color SunLightColor = new(0.6901961f, 0.6901961f, 0.6901961f, 1);
 
         [Range(0, 1)]
@@ -73,8 +85,11 @@ namespace GUZ.Core
         public GameTimeInterval SunUpdateInterval = GameTimeInterval.EveryGameHour;
 
         public Color AmbientLightColor = new(0.10196079f, 0.10196079f, 0.10196079f, 1);
+#endregion
 
-        [Header("### Time ###")]
+
+#region Time
+        [Foldout("Time", true)]
         [Range(0, 23)]
         public int StartTimeHour = 8;
 
@@ -83,36 +98,49 @@ namespace GUZ.Core
 
         [Range(0.5f, 1000f)]
         public float TimeSpeedMultiplier = 1;
+#endregion
 
-        [Header("### WayNet ###")]
+
+#region WayNet
+        [Foldout("WayNet", true)]
         public bool ShowFreePoints;
 
         public bool ShowWayPoints;
 
         public bool ShowWayEdges;
+#endregion
 
-        [Header("### Culling ###")]
+
+#region Culling
+        [Foldout("Culling", true)]
+        [Separator("Misc")]
         public bool EnableSoundCulling = true;
 
         public bool EnableMeshCulling = true;
 
         public bool ShowMeshCullingGizmos = true;
 
+        [Separator("VOB Culling")]
         public MeshCullingGroup SmallMeshCullingGroup = new() { MaximumObjectSize = 0.2f, CullingDistance = 50 };
 
         public MeshCullingGroup MediumMeshCullingGroup = new() { MaximumObjectSize = 5.0f, CullingDistance = 100 };
 
         public MeshCullingGroup LargeMeshCullingGroup = new() { MaximumObjectSize = 100, CullingDistance = 200 };
+#endregion
 
-        [Header("### Logging ###")]
+
+#region Logging
+        [Foldout("Logging", true)]
         [InspectorName("ZenKit Log Level")]
         public LogLevel ZenkitLogLevel = LogLevel.Warning;
+
+        [Tooltip("Enable Daedalus logs which are called ZSpyLogs inside .d scripts.")]
+        public bool EnableSpyLogs;
 
         [InspectorName("DirectMusic Log Level")]
         public DirectMusic.LogLevel DirectMusicLogLevel = DirectMusic.LogLevel.Warning;
 
         public bool EnableBarrierLogs;
-
-        public bool EnableSpyLogs;
+#endregion
     }
 }

--- a/Assets/Gothic-UnZENity-Core/Scripts/GameConfiguration.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/GameConfiguration.cs
@@ -23,8 +23,11 @@ namespace GUZ.Core
     public class GameConfiguration : ScriptableObject
     {
 
-#region ConditionalFieldArrayFilter
         /**
+         * ##########
+         * ConditionalFieldArrayFilter
+         * ##########
+         *
          * Unity doesn't support custom drawer on Arrays. MyBox came up with a solution by wrapping a list into a wrapper class.
          * @see: https://github.com/Deadcows/MyBox/wiki/Attributes#conditionalfield-with-arrays
          */
@@ -34,17 +37,25 @@ namespace GUZ.Core
 
         [Serializable]
         public class VOBTypesCollection : CollectionWrapper<VirtualObjectType> { }
-#endregion
 
 
-#region Controls
+        /**
+         * ##########
+         * Controls
+         * ##########
+         */
+
         [Foldout("Controls", true)]
         public GuzContext.Controls GameControls = GuzContext.Controls.HVR;
         public bool EnableDeviceSimulator;
-#endregion
 
 
-#region Logging
+        /**
+         * ##########
+         * Logging
+         * ##########
+         */
+
         [Foldout("Logging", true)]
         [OverrideLabel("ZenKit Log Level")]
         public LogLevel ZenKitLogLevel = LogLevel.Warning;
@@ -56,10 +67,14 @@ namespace GUZ.Core
         [OverrideLabel("DirectMusic Log Level")]
         public DirectMusic.LogLevel DirectMusicLogLevel = DirectMusic.LogLevel.Warning;
         public bool EnableBarrierLogs;
-#endregion
 
 
-#region Menu and Loading
+        /**
+         * ##########
+         * Menu and Loading
+         * ##########
+         */
+
         [Foldout("Menu and Loading", true)]
         public bool EnableMainMenu = true;
 
@@ -70,10 +85,14 @@ namespace GUZ.Core
         [Range(1, 15)]
         public int SaveSlotToLoad;
         private bool SaveSlotFieldCondition() => !EnableMainMenu && LoadFromSaveSlot;
-#endregion
 
 
-#region VOBs
+        /**
+         * ##########
+         * VOBs
+         * ##########
+         */
+
         [Foldout("VOBs", true)]
         [Separator("General")]
         [Tooltip("Enable World objects.")]
@@ -99,10 +118,14 @@ namespace GUZ.Core
         [ConditionalField(fieldToCheck: nameof(EnableVOBMeshCulling), compareValues: true)]
         [Tooltip("For debugging purposes only.")]
         public bool ShowVOBMeshCullingGizmos;
-#endregion
 
 
-#region NPCs
+        /**
+         * ##########
+         * NPCs
+         * ##########
+         */
+
         [Foldout("NPCs", true)]
         [Tooltip("Currently focusing on Old Camp NPCs.")]
         [OverrideLabel("Spawn NPCs")]
@@ -118,10 +141,14 @@ namespace GUZ.Core
         [Tooltip("WIP - Not production ready.")]
         [ConditionalField(fieldToCheck: nameof(SpawnNPCs), compareValues: true)]
         public bool EnableNPCEyeBlinking;
-#endregion
 
 
-#region WayNet
+        /**
+         * ##########
+         * WayNet
+         * ##########
+         */
+
         [Foldout("WayNet", true)]
         [OverrideLabel("Show Free Point Meshes")]
         public bool ShowFreePoints;
@@ -134,18 +161,26 @@ namespace GUZ.Core
 
         [Tooltip("Covers Free Points and Way Points.")]
         public string SpawnAtWaypoint = string.Empty;
-#endregion
 
 
-#region Audio
+        /**
+         * ##########
+         * Audio
+         * ##########
+         */
+
         [Foldout("Audio", true)]
         public bool EnableGameMusic = true;
         public bool EnableGameSounds = true;
         public bool EnableSoundCulling = true;
-#endregion
 
 
-#region Lighting
+        /**
+         * ##########
+         * Lighting
+         * ##########
+         */
+
         [Foldout("Lighting", true)]
         public Color SunLightColor = new(0.69f, 0.69f, 0.69f, 1);
 
@@ -153,10 +188,14 @@ namespace GUZ.Core
         public float SunLightIntensity = 1;
         public GameTimeInterval SunUpdateInterval = GameTimeInterval.EveryGameMinute;
         public Color AmbientLightColor = new(0.1f, 0.1f, 0.1f, 1);
-#endregion
 
 
-#region Time
+        /**
+         * ##########
+         * Time
+         * ##########
+         */
+
         [Foldout("Time", true)]
         [Range(0, 23)]
         public int StartTimeHour = 8;
@@ -167,10 +206,14 @@ namespace GUZ.Core
         [Range(0.5f, 1000f)]
         [Tooltip("Speeds up the in game time.")]
         public float TimeSpeedMultiplier = 1;
-#endregion
 
 
-#region Misc
+        /**
+         * ##########
+         * Misc
+         * ##########
+         */
+
         [Foldout("Misc", true)]
         [Separator("Meshes/Visuals")]
         public bool EnableWorldMesh = true;
@@ -179,7 +222,6 @@ namespace GUZ.Core
         [Separator("WIP - Not production ready", true)]
         public bool EnableDecalVisuals;
         public bool EnableParticleEffects;
-#endregion
 
     }
 }

--- a/Assets/Gothic-UnZENity-Core/Scripts/GameConfiguration.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/GameConfiguration.cs
@@ -19,72 +19,93 @@ namespace GUZ.Core
         public float CullingDistance;
     }
 
-    [CreateAssetMenu(fileName = "Data", menuName = "ScriptableObjects/GameConfiguration", order = 1)]
+    [CreateAssetMenu(fileName = "NewGameConfiguration", menuName = "UnZENity/ScriptableObjects/GameConfiguration", order = 1)]
     public class GameConfiguration : ScriptableObject
     {
+
 #region Controls
         [Foldout("Controls", true)]
-        public GuzContext.Controls GameControls = GuzContext.Controls.VRXrit;
-
+        public GuzContext.Controls GameControls = GuzContext.Controls.HVR;
         public bool EnableDeviceSimulator;
 #endregion
 
 
-#region Developer
-        [Foldout("Developer", true)]
-        public bool EnableMainMenu = true;
+#region Logging
+        [Foldout("Logging", true)]
+        [OverrideLabel("ZenKit Log Level")]
+        public LogLevel ZenKitLogLevel = LogLevel.Warning;
 
+        [Tooltip("Enable Daedalus logs inside .d scripts.")]
+        public bool EnableZSpyLogs;
+
+        [OverrideLabel("DirectMusic Log Level")]
+        public DirectMusic.LogLevel DirectMusicLogLevel = DirectMusic.LogLevel.Warning;
+        public bool EnableBarrierLogs;
+#endregion
+
+
+#region Menu and Loading
+        [Foldout("Menu and Loading", true)]
+        public bool EnableMainMenu = true;
         public bool LoadFromSaveSlot;
 
         [Range(1, 15)]
         public int SaveSlotToLoad;
         private bool SaveSlotPredicate() => !EnableMainMenu && LoadFromSaveSlot;
+#endregion
 
+
+#region VOBs
+        [Foldout("VOBs", true)]
+        [Tooltip("Enable World objects.")]
+        public bool EnableVOBs = true;
+
+        [Tooltip("Spawn only specific VOBs by naming their types in here.")]
+        public List<VirtualObjectType> SpawnVOBTypes = new();
+#endregion
+
+
+#region NPCs
+        [Foldout("NPCs", true)]
         public bool SpawnOldCampNpcs;
-
         public bool EnableNpcRoutines;
 
-        public string SpawnAtWaypoint = string.Empty;
-
-        public bool EnableWorldObjects = true;
-
-        public bool EnableWorldMesh = true;
-
-        public bool EnableBarrierVisual = true;
-
-        [InspectorName("Experimental: Enable Decal Visuals")]
-        public bool EnableDecalVisuals;
-
-        [InspectorName("Experimental: Enable Particle Effects")]
-        public bool EnableParticleEffects;
-
-        [InspectorName("Experimental: Enable NPC Eye Blinking")]
-        public bool EnableNpcEyeBlinking;
-
-        public List<VirtualObjectType> SpawnWorldObjectTypes = new();
-
+        [Tooltip("Spawn only specific NPCs by naming their IDs in here.")]
         public List<int> SpawnNpcInstances = new();
+#endregion
+
+
+#region WayNet
+        [Foldout("WayNet", true)]
+        [OverrideLabel("Show Free Point Meshes")]
+        public bool ShowFreePoints;
+
+        [OverrideLabel("Show Way Point Meshes")]
+        public bool ShowWayPoints;
+
+        [OverrideLabel("Show Way Point Edge Meshes")]
+        public bool ShowWayEdges;
+
+        [Tooltip("Covers Free Points and Way Points.")]
+        public string SpawnAtWaypoint = string.Empty;
 #endregion
 
 
 #region Audio
         [Foldout("Audio", true)]
         public bool EnableGameMusic = true;
-
         public bool EnableGameSounds = true;
 #endregion
 
 
 #region Lighting
         [Foldout("Lighting", true)]
-        public Color SunLightColor = new(0.6901961f, 0.6901961f, 0.6901961f, 1);
+        public Color SunLightColor = new(0.69f, 0.69f, 0.69f, 1);
 
         [Range(0, 1)]
         public float SunLightIntensity = 1;
-
-        public GameTimeInterval SunUpdateInterval = GameTimeInterval.EveryGameHour;
-
-        public Color AmbientLightColor = new(0.10196079f, 0.10196079f, 0.10196079f, 1);
+        public GameTimeInterval SunUpdateInterval = GameTimeInterval.EveryGameMinute;
+        public Color AmbientLightColor = new(0.1f, 0.1f, 0.1f, 1);
 #endregion
 
 
@@ -97,50 +118,39 @@ namespace GUZ.Core
         public int StartTimeMinute;
 
         [Range(0.5f, 1000f)]
+        [Tooltip("Speeds up the in game time.")]
         public float TimeSpeedMultiplier = 1;
-#endregion
-
-
-#region WayNet
-        [Foldout("WayNet", true)]
-        public bool ShowFreePoints;
-
-        public bool ShowWayPoints;
-
-        public bool ShowWayEdges;
 #endregion
 
 
 #region Culling
         [Foldout("Culling", true)]
+        [Separator("VOBs")]
+        public MeshCullingGroup SmallMeshCullingGroup = new() { MaximumObjectSize = 0.2f, CullingDistance = 50 };
+        public MeshCullingGroup MediumMeshCullingGroup = new() { MaximumObjectSize = 5.0f, CullingDistance = 100 };
+        public MeshCullingGroup LargeMeshCullingGroup = new() { MaximumObjectSize = 100, CullingDistance = 200 };
+
         [Separator("Misc")]
         public bool EnableSoundCulling = true;
-
         public bool EnableMeshCulling = true;
-
-        public bool ShowMeshCullingGizmos = true;
-
-        [Separator("VOB Culling")]
-        public MeshCullingGroup SmallMeshCullingGroup = new() { MaximumObjectSize = 0.2f, CullingDistance = 50 };
-
-        public MeshCullingGroup MediumMeshCullingGroup = new() { MaximumObjectSize = 5.0f, CullingDistance = 100 };
-
-        public MeshCullingGroup LargeMeshCullingGroup = new() { MaximumObjectSize = 100, CullingDistance = 200 };
+        public bool ShowMeshCullingGizmos;
 #endregion
 
 
-#region Logging
-        [Foldout("Logging", true)]
-        [InspectorName("ZenKit Log Level")]
-        public LogLevel ZenkitLogLevel = LogLevel.Warning;
-
-        [Tooltip("Enable Daedalus logs which are called ZSpyLogs inside .d scripts.")]
-        public bool EnableSpyLogs;
-
-        [InspectorName("DirectMusic Log Level")]
-        public DirectMusic.LogLevel DirectMusicLogLevel = DirectMusic.LogLevel.Warning;
-
-        public bool EnableBarrierLogs;
+#region Misc
+        [Foldout("Misc", true)]
+        [Separator("Meshes/Visuals")]
+        public bool EnableWorldMesh = true;
+        public bool EnableBarrierVisual = true;
 #endregion
+
+
+#region Experimental - Not production ready
+        [Foldout("Experimental - Not production ready", true)]
+        public bool EnableDecalVisuals;
+        public bool EnableParticleEffects;
+        public bool EnableNpcEyeBlinking;
+#endregion
+
     }
 }

--- a/Assets/Gothic-UnZENity-Core/Scripts/GameManager.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/GameManager.cs
@@ -99,7 +99,7 @@ namespace GUZ.Core
 
         private void Start()
         {
-            Logger.Set(Config.ZenkitLogLevel, Logging.OnZenKitLogMessage);
+            Logger.Set(Config.ZenKitLogLevel, Logging.OnZenKitLogMessage);
             DirectMusic.Logger.Set(Config.DirectMusicLogLevel, Logging.OnDirectMusicLogMessage);
 
             _fileLoggingHandler.Init();

--- a/Assets/Gothic-UnZENity-Core/Scripts/Manager/Culling/VobMeshCullingManager.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Manager/Culling/VobMeshCullingManager.cs
@@ -50,11 +50,11 @@ namespace GUZ.Core.Manager.Culling
         public VobMeshCullingManager(GameConfiguration config, ICoroutineManager coroutineManager)
         {
             _coroutineManager = coroutineManager;
-            _featureEnableCulling = config.EnableMeshCulling;
-            _featureDrawGizmos = config.ShowMeshCullingGizmos;
-            _featureSmallCullingGroup = config.SmallMeshCullingGroup;
-            _featureMediumCullingGroup = config.MediumMeshCullingGroup;
-            _featureLargeCullingGroup = config.LargeMeshCullingGroup;
+            _featureEnableCulling = config.EnableVOBMeshCulling;
+            _featureDrawGizmos = config.ShowVOBMeshCullingGizmos;
+            _featureSmallCullingGroup = config.SmallVOBMeshCullingGroup;
+            _featureMediumCullingGroup = config.MediumVOBMeshCullingGroup;
+            _featureLargeCullingGroup = config.LargeVOBMeshCullingGroup;
         }
 
         public void Init()

--- a/Assets/Gothic-UnZENity-Core/Scripts/Manager/GUZSceneManager.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Manager/GUZSceneManager.cs
@@ -92,7 +92,7 @@ namespace GUZ.Core.Manager
 
             // We load NPCs only! if we have a fresh game start.
             // TODO - We need to properly update this logic to reflect world switches for the first time as well (even from save games).
-            if (_config.SpawnOldCampNpcs && !_config.LoadFromSaveSlot)
+            if (_config.SpawnNPCs && !_config.LoadFromSaveSlot)
             {
                 GameData.GothicVm.Call("STARTUP_SUB_OLDCAMP");
             }

--- a/Assets/Gothic-UnZENity-Core/Scripts/Manager/NpcHelper.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Manager/NpcHelper.cs
@@ -563,7 +563,7 @@ namespace GUZ.Core.Manager
             GameData.GothicVm.GlobalSelf = npcInstance;
             GameData.GothicVm.Call(routineIndex);
 
-            if (!GameGlobals.Config.EnableNpcRoutines)
+            if (!GameGlobals.Config.EnableNPCRoutines)
             {
                 return;
             }

--- a/Assets/Gothic-UnZENity-Core/Scripts/Manager/RoutineManager.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Manager/RoutineManager.cs
@@ -18,7 +18,7 @@ namespace GUZ.Core.Manager
 
         public RoutineManager(GameConfiguration config)
         {
-            _featureEnable = config.EnableNpcRoutines;
+            _featureEnable = config.EnableNPCRoutines;
             _featureStartHour = config.StartTimeHour;
             _featureStartMinute = config.StartTimeMinute;
         }

--- a/Assets/Gothic-UnZENity-Core/Scripts/Npc/HeadMorph.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Npc/HeadMorph.cs
@@ -28,7 +28,7 @@ namespace GUZ.Core.Npc
         {
             base.Start();
 
-            if (!GameGlobals.Config.EnableNpcEyeBlinking)
+            if (!GameGlobals.Config.EnableNPCEyeBlinking)
             {
                 return;
             }

--- a/Assets/Gothic-UnZENity-Core/Scripts/Vm/VmGothicExternals.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Vm/VmGothicExternals.cs
@@ -429,7 +429,7 @@ namespace GUZ.Core.Vm
 
         public static void PrintDebug(string message)
         {
-            if (!GameGlobals.Config.EnableSpyLogs)
+            if (!GameGlobals.Config.EnableZSpyLogs)
             {
                 return;
             }
@@ -440,7 +440,7 @@ namespace GUZ.Core.Vm
 
         public static void PrintDebugCh(int channel, string message)
         {
-            if (!GameGlobals.Config.EnableSpyLogs)
+            if (!GameGlobals.Config.EnableZSpyLogs)
             {
                 return;
             }
@@ -451,7 +451,7 @@ namespace GUZ.Core.Vm
 
         public static void PrintDebugInst(string message)
         {
-            if (!GameGlobals.Config.EnableSpyLogs)
+            if (!GameGlobals.Config.EnableZSpyLogs)
             {
                 return;
             }
@@ -462,7 +462,7 @@ namespace GUZ.Core.Vm
 
         public static void PrintDebugInstCh(int channel, string message)
         {
-            if (!GameGlobals.Config.EnableSpyLogs)
+            if (!GameGlobals.Config.EnableZSpyLogs)
             {
                 return;
             }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,7 @@
 {
   "dependencies": {
+    "com.domybest.mybox": "https://github.com/Deadcows/MyBox.git",
+    "com.hurricanevrextensions.simulator": "https://github.com/Gothic-UnZENity-Project/hvr-simulator.git",
     "com.unity.collab-proxy": "2.3.1",
     "com.unity.feature.development": "1.0.1",
     "com.unity.ide.rider": "3.0.28",
@@ -14,7 +16,6 @@
     "com.unity.xr.openxr": "1.8.2",
     "com.unity.xr.openxr.picoxr": "https://github.com/Gothic-UnZENity-Project/pico-openxr-sdk.git",
     "com.unzenity.core.binaries": "https://github.com/Gothic-UnZENity-Project/binary-dependencies.git?path=/Gothic-UnZENity-Core",
-    "com.hurricanevrextensions.simulator": "https://github.com/Gothic-UnZENity-Project/hvr-simulator.git",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,5 +1,14 @@
 {
   "dependencies": {
+    "com.domybest.mybox": {
+      "version": "https://github.com/Deadcows/MyBox.git",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {
+        "com.unity.ugui": "1.0.0"
+      },
+      "hash": "cbff7090303fac1067f69654ede33d11e2ccd0c1"
+    },
     "com.hurricanevrextensions.simulator": {
       "version": "https://github.com/Gothic-UnZENity-Project/hvr-simulator.git",
       "depth": 0,

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -848,7 +848,7 @@ PlayerSettings:
   webGLPowerPreference: 2
   scriptingDefineSymbols:
     Android: USE_INPUT_SYSTEM_POSE_CONTROL
-    Standalone: USE_INPUT_SYSTEM_POSE_CONTROL
+    Standalone: USE_INPUT_SYSTEM_POSE_CONTROL;GUZ_HVR_INSTALLED
     Windows Store Apps: USE_INPUT_SYSTEM_POSE_CONTROL
   additionalCompilerArguments: {}
   platformArchitecture: {}


### PR DESCRIPTION
I rearranged the lables and groupings of GameConfiguration.
![image](https://github.com/Gothic-UnZENity-Project/Gothic-UnZENity/assets/120568393/6b0d0df0-b672-4e07-a34e-c4ca0cf156ed)

I also added a community package which provided features like Separator, Groups, and LabelOverrides.
https://github.com/Deadcows/MyBox  
It has 1.9k GitHub stars and is recommended within Unity Forums multiple times. It mostly contains Editor code #ifdef UNITY_EDITOR and therefore won't affect our production builds.

**To Test**:
* Please review the changes and suggest alternatives if you want to rename/reorder some fields.
* Check briefly if the game loads (But I didn't alter the actual asset-GUID. Therefore it should work as before)
* Also some fields will display only if conditions are met. These are:
    * LoadFromSaveSlot & SaveSlotToLoad -> Dependent on EnableMainMenu
    * *MeshCullingGroup & ShowVOBMeshCullingGizmos -> Dependent on EnableVOBMeshCulling
    * EnableNPCRoutines & SpawnNPCInstances -> Dependent on SpawnNPCs

Hint: With the default value changes, I changed the default Controls from XRIT to HVR. I added a troubleshooting note inside Developer documentation as well: https://github.com/Gothic-UnZENity-Project/Gothic-UnZENity/wiki/Developer's-Guide