### PR TITLE
update(.gitignore): Marked local GameConfigurations as do-not-commit.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ Assets/HurricaneVR/
 # Do not commit local development settings
 Assets/StreamingAssets/GameSettings.dev.json
 Assets/StreamingAssets/GameSettings.dev.json.meta
+Assets/Gothic-UnZENity-Core/Resources/GameConfigurations/*.dev.asset
+Assets/Gothic-UnZENity-Core/Resources/GameConfigurations/*.dev.asset.meta


### PR DESCRIPTION
When working with various GameConfigurations, the fast way of cloning them and altering a few values is of great use. During development there are multiple times when I would like to store more configs than I want to commit.

I therefore thought about having it similar to GameSettings.dev.json. i.e. whenever we put an .dev.asset at the end of the GameConfiguration instance, we won't clutter our git commit view.