### PR TITLE
Feature/auto string encoding select

### DIFF
--- a/Assets/Gothic-UnZENity-Core/Editor/Scripts/Tools/OcclusionCullingTool.cs
+++ b/Assets/Gothic-UnZENity-Core/Editor/Scripts/Tools/OcclusionCullingTool.cs
@@ -35,7 +35,6 @@ namespace GUZ.Core.Editor.Tools
             }
 
             var settings = GameSettings.Load();
-            GuzBootstrapper.SetLanguage(settings.GothicILanguage);
             ResourceLoader.Init(settings.GothicIPath);
 
             WorldCreator.LoadEditorWorld();

--- a/Assets/Gothic-UnZENity-Core/Scripts/GameManager.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/GameManager.cs
@@ -65,7 +65,7 @@ namespace GUZ.Core
 
             _gameMusicManager.Init();
 
-            GuzBootstrapper.BootGothicUnZeNity(Config, Settings.GothicIPath, Settings.GothicILanguage);
+            GuzBootstrapper.BootGothicUnZeNity(Config, Settings.GothicIPath);
             Scene.LoadStartupScenes();
 
             if (Config.EnableBarrierVisual)

--- a/Assets/Gothic-UnZENity-Core/Scripts/GameSettings.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/GameSettings.cs
@@ -13,11 +13,7 @@ namespace GUZ.Core.Manager.Settings
         private const string _settingsFileNameDev = "GameSettings.dev.json";
 
         public string GothicIPath;
-        public string GothicILanguage;
         public string LogLevel;
-
-        public string GothicMenuFontPath;
-        public string GothicSubtitleFontPath;
 
         public Dictionary<string, Dictionary<string, string>> GothicIniSettings = new();
 

--- a/Assets/Gothic-UnZENity-Lab/Scripts/LabBootstrapper.cs
+++ b/Assets/Gothic-UnZENity-Lab/Scripts/LabBootstrapper.cs
@@ -83,7 +83,7 @@ namespace GUZ.Lab
             _isBooted = true;
 
             var settings = _settings;
-            GuzBootstrapper.BootGothicUnZeNity(Config, settings.GothicIPath, settings.GothicILanguage);
+            GuzBootstrapper.BootGothicUnZeNity(Config, settings.GothicIPath);
 
             BootLab();
 

--- a/Assets/StreamingAssets/GameSettings.json
+++ b/Assets/StreamingAssets/GameSettings.json
@@ -1,7 +1,4 @@
 ﻿{
     "GothicIPath": "---Please set it to the path where your game is installed---",
-    "GothicILanguage": "---Supported values are cs/en/de/fr/it/pl/es/ru---",
-    "LogLevel": "---Set log level to one of these values: Debug/Warning/Error/Exception---",
-    "GothicMenuFontPath": "---(Optional) If it points to an official Gothic font (e.g. from worldofgothic), it will be picked and used for menu texts.---",
-    "GothicSubtitleFontPath": "---(Optional) If it points to an official Gothic font (e.g. from worldofgothic), it will be picked and used for subtitles.---"
+    "LogLevel": "---Set log level to one of these values: Debug/Warning/Error/Exception---"
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -4,7 +4,7 @@
     "com.hurricanevrextensions.simulator": "https://github.com/Gothic-UnZENity-Project/hvr-simulator.git",
     "com.unity.collab-proxy": "2.3.1",
     "com.unity.feature.development": "1.0.1",
-    "com.unity.ide.rider": "3.0.28",
+    "com.unity.ide.rider": "3.0.31",
     "com.unity.mobile.android-logcat": "1.4.1",
     "com.unity.render-pipelines.universal": "14.0.11",
     "com.unity.textmeshpro": "3.2.0-pre.6",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -62,7 +62,7 @@
       }
     },
     "com.unity.ide.rider": {
-      "version": "3.0.28",
+      "version": "3.0.31",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
Less configuration means easier use for our gamers!

I shrinked the GameSettings.json. Players now need to set only two values:
1. G1 installation directory
2. LogLevel

Fonts are already auto-created and now we also select StringEncoding based on some internal Daedalus value checks of Daedalus constants.

## To test
* Install game in certain languages
* Check for this log message: _Selecting StringEncoding=..._
* Check if NPC names match language specific titles. e.g. check if russion names in Scene hierarchy are in cyrillic letters