### PR TITLE
add(HurricaneTool): MenuItem implemented to automatically convert HVR materials from built-in to URP.

### DIFF
--- a/Assets/Gothic-UnZENity-Core/Editor/Scripts/Tools/ContextTool.cs
+++ b/Assets/Gothic-UnZENity-Core/Editor/Scripts/Tools/ContextTool.cs
@@ -41,7 +41,7 @@ namespace GUZ.Core.Editor.Tools
             ActivatePlugin(NamedBuildTarget.Android);
         }
 
-        public static void ActivatePlugin(NamedBuildTarget target)
+        private static void ActivatePlugin(NamedBuildTarget target)
         {
             // Change compile flag in PlayerSettings
             var settings = PlayerSettings.GetScriptingDefineSymbols(target)
@@ -67,7 +67,7 @@ namespace GUZ.Core.Editor.Tools
             DeactivatePlugin(NamedBuildTarget.Android);
         }
 
-        public static void DeactivatePlugin(NamedBuildTarget target)
+        private static void DeactivatePlugin(NamedBuildTarget target)
         {
             var settings = PlayerSettings.GetScriptingDefineSymbols(target)
                 .Split(";")

--- a/Assets/Gothic-UnZENity-HVR/Editor.meta
+++ b/Assets/Gothic-UnZENity-HVR/Editor.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9850a4b17ac8416f82ea116e78b6b515
+timeCreated: 1723449136

--- a/Assets/Gothic-UnZENity-HVR/Editor/HurricaneTool.cs
+++ b/Assets/Gothic-UnZENity-HVR/Editor/HurricaneTool.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEditor.Rendering;
+using UnityEditor.Rendering.Universal;
+using UnityEngine;
+
+namespace GUZ.HVR.Editor
+{
+    public class HurricaneTool
+    {
+        private static string[] _hvrMaterialFolders = { "Assets/HurricaneVR/Framework/Materials", "Assets/HurricaneVR/TechDemo/Materials" };
+        
+        /// <summary>
+        /// Leveraging Unity's implementation of MaterialConversion.
+        /// @see documentation: https://docs.unity3d.com/Packages/com.unity.render-pipelines.universal@17.0/manual/features/rp-converter.html
+        /// @see source code (for more MaterialUpgraders if needed): UnityEditor.Rendering.Universal.UniversalRenderPipelineMaterialUpgrader:GetUpgraders()
+        /// </summary>
+        [MenuItem("Gothic-UnZENity/Context/HVR - Convert Materials to URP")]
+        private static void ConvertHVRMaterialToURP()
+        {
+            var upgrader = new StandardUpgrader("Standard");
+            var materialFiles = new List<string>();
+            
+            foreach (var folder in _hvrMaterialFolders)
+            {
+                materialFiles.AddRange(Directory.GetFiles(folder, "*.mat"));
+            }
+
+            foreach (var materialFile in materialFiles)
+            {
+                var materialToConvert = AssetDatabase.LoadAssetAtPath<Material>(materialFile);
+                upgrader.Upgrade(materialToConvert, MaterialUpgrader.UpgradeFlags.LogMessageWhenNoUpgraderFound);
+                Debug.Log($"Material >{materialToConvert.name}< converted to URP");
+            }
+        }
+    }
+}

--- a/Assets/Gothic-UnZENity-HVR/Editor/HurricaneTool.cs.meta
+++ b/Assets/Gothic-UnZENity-HVR/Editor/HurricaneTool.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7e882ebc5f8a4864b3d90fc0666faf9e
+timeCreated: 1723449146


### PR DESCRIPTION
When we install .unitypackage of HVR for the first time, we need to migrate the materials to URP. I built a menu entry to do it automatically. It can be used for:
1. New installation of Unity project locally
2. Pipeline installs project and calls this MenuItem to convert the materials automatically


## Before:
![image](https://github.com/user-attachments/assets/47e3738b-3d72-4284-a5cd-8d6de6a82301)
![image](https://github.com/user-attachments/assets/57601408-a51c-483c-8a94-97556817109a)

## Execute:
![image](https://github.com/user-attachments/assets/fbcdfc05-9d5e-4864-9690-9e49b9a1be58)

## After:
![image](https://github.com/user-attachments/assets/ab7de0a4-4989-483a-acc7-0f6358a481d4)
![image](https://github.com/user-attachments/assets/5d3baf33-f409-4af1-8886-21a664b759b9)

