### PR TITLE
Feature/29 hvr fix in game menu usage

### DIFF
--- a/Assets/Gothic-UnZENity-Core/Resources/Prefabs/Menus/MainMenu.prefab
+++ b/Assets/Gothic-UnZENity-Core/Resources/Prefabs/Menus/MainMenu.prefab
@@ -14931,12 +14931,11 @@ Transform:
   m_GameObject: {fileID: 5827635276208223651}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1500, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6399765361351343797}
-  - {fileID: 3712311183497280628}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2544490654052458057
@@ -14961,7 +14960,6 @@ MonoBehaviour:
   MovementMenuHandler: {fileID: 0}
   MusicVolumeHandler: {fileID: 2497713652577780456}
   SoundEffectsVolumeHandler: {fileID: 1309024636248075069}
-  MainMenuImageBackground: {fileID: 7482032981081934149}
   MainMenuBackground: {fileID: 3202749196069333594}
   MainMenuSaveLoadBackground: {fileID: 2128873841547656005}
   MainMenuText: {fileID: 6206898237742856468}
@@ -15741,11 +15739,10 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6127533591070308652}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 4}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.02, y: 0.02, z: 0.02}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3728847125714195622}
   - {fileID: 8117808233648950769}
   - {fileID: 4848574707946555843}
   - {fileID: 135058072969220654}
@@ -15760,7 +15757,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 1.3}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 800, y: 600}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &5683023942457062724
@@ -18305,115 +18302,6 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
---- !u!1 &7482032981081934149
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3728847125714195622}
-  - component: {fileID: 1610869287009712635}
-  - component: {fileID: 2308456069722895187}
-  - component: {fileID: 5647168685112422126}
-  m_Layer: 5
-  m_Name: MenuBackgroundImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &3728847125714195622
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7482032981081934149}
-  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0.02}
-  m_LocalScale: {x: -40, y: 8, z: 32}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6399765361351343797}
-  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!33 &1610869287009712635
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7482032981081934149}
-  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &2308456069722895187
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7482032981081934149}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials: []
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!64 &5647168685112422126
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7482032981081934149}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 0
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &7563734354672163922
 GameObject:
   m_ObjectHideFlags: 0
@@ -20269,124 +20157,6 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
---- !u!1 &9056398756497634017
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3712311183497280628}
-  - component: {fileID: 5143388864121904476}
-  - component: {fileID: 6774589647382043084}
-  m_Layer: 5
-  m_Name: Light
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3712311183497280628
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9056398756497634017}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7559068981978770}
-  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!108 &5143388864121904476
-Light:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9056398756497634017}
-  m_Enabled: 1
-  serializedVersion: 10
-  m_Type: 1
-  m_Shape: 0
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Intensity: 1
-  m_Range: 10
-  m_SpotAngle: 30
-  m_InnerSpotAngle: 21.80208
-  m_CookieSize: 10
-  m_Shadows:
-    m_Type: 0
-    m_Resolution: -1
-    m_CustomResolution: -1
-    m_Strength: 1
-    m_Bias: 0.05
-    m_NormalBias: 0.4
-    m_NearPlane: 0.2
-    m_CullingMatrixOverride:
-      e00: 1
-      e01: 0
-      e02: 0
-      e03: 0
-      e10: 0
-      e11: 1
-      e12: 0
-      e13: 0
-      e20: 0
-      e21: 0
-      e22: 1
-      e23: 0
-      e30: 0
-      e31: 0
-      e32: 0
-      e33: 1
-    m_UseCullingMatrixOverride: 0
-  m_Cookie: {fileID: 0}
-  m_DrawHalo: 0
-  m_Flare: {fileID: 0}
-  m_RenderMode: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingLayerMask: 1
-  m_Lightmapping: 4
-  m_LightShadowCasterMode: 0
-  m_AreaSize: {x: 1, y: 1}
-  m_BounceIntensity: 1
-  m_ColorTemperature: 6570
-  m_UseColorTemperature: 0
-  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_UseBoundingSphereOverride: 0
-  m_UseViewFrustumForShadowCasterCull: 1
-  m_ShadowRadius: 0
-  m_ShadowAngle: 0
---- !u!114 &6774589647382043084
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9056398756497634017}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Version: 3
-  m_UsePipelineSettings: 1
-  m_AdditionalLightsShadowResolutionTier: 2
-  m_LightLayerMask: 1
-  m_RenderingLayers: 1
-  m_CustomShadowLayers: 0
-  m_ShadowLayerMask: 1
-  m_ShadowRenderingLayers: 1
-  m_LightCookieSize: {x: 1, y: 1}
-  m_LightCookieOffset: {x: 0, y: 0}
-  m_SoftShadowQuality: 0
 --- !u!1001 &2062597649572768423
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Gothic-UnZENity-Core/Scenes/MainMenu.unity
+++ b/Assets/Gothic-UnZENity-Core/Scenes/MainMenu.unity
@@ -227,6 +227,129 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!224 &1294430405 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6399765361351343797, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+  m_PrefabInstance: {fileID: 7604298098518958908}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1308095009
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1308095010}
+  - component: {fileID: 1308095012}
+  - component: {fileID: 1308095011}
+  m_Layer: 5
+  m_Name: Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1308095010
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1308095009}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7604298098518958911}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &1308095011
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1308095009}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+--- !u!108 &1308095012
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1308095009}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
 --- !u!1 &1478698493
 GameObject:
   m_ObjectHideFlags: 0
@@ -310,6 +433,115 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2031667426
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2031667427}
+  - component: {fileID: 2031667430}
+  - component: {fileID: 2031667429}
+  - component: {fileID: 2031667428}
+  m_Layer: 5
+  m_Name: MenuBackgroundImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2031667427
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2031667426}
+  m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0.02}
+  m_LocalScale: {x: -40, y: 8, z: 32}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1294430405}
+  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!64 &2031667428
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2031667426}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2031667429
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2031667426}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials: []
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2031667430
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2031667426}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &7604298098518958908
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -324,11 +556,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
       propertyPath: m_LocalRotation.w
@@ -364,9 +596,41 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      insertIndex: 0
+      addedObject: {fileID: 1308095010}
+    - targetCorrespondingSourceObject: {fileID: 6399765361351343797, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      insertIndex: 0
+      addedObject: {fileID: 2031667427}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5827635276208223651, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      insertIndex: 1
+      addedObject: {fileID: 7604298098518958910}
   m_SourcePrefab: {fileID: 100100000, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+--- !u!1 &7604298098518958909 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5827635276208223651, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+  m_PrefabInstance: {fileID: 7604298098518958908}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7604298098518958910
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7604298098518958909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e421d90117014e11a76cc17dd4c7a4c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _mainMenuImageBackground: {fileID: 2031667426}
+--- !u!4 &7604298098518958911 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+  m_PrefabInstance: {fileID: 7604298098518958908}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Gothic-UnZENity-Core/Scripts/GlobalEventDispatcher.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/GlobalEventDispatcher.cs
@@ -37,5 +37,8 @@ namespace GUZ.Core
         public static readonly UnityEvent<GameObject> MusicZoneEntered = new();
         public static readonly UnityEvent<GameObject> MusicZoneExited = new();
         public static readonly UnityEvent<string, string> LevelChangeTriggered = new();
+        
+        public static readonly UnityEvent<string, object> PlayerPrefUpdated = new();
+
     }
 }

--- a/Assets/Gothic-UnZENity-Core/Scripts/Manager/PlayerPrefsManager.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Manager/PlayerPrefsManager.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using GUZ.Core.Globals;
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace GUZ.Core.Manager
 {
     public class PlayerPrefsManager
     {
+        public static UnityEvent<string, object> PlayerPrefsUpdated = new();
+
         // Movement - Direction
         private const int _directionModeCamera = 0;
         private const int _directionModeLeftController = 1;
@@ -28,28 +31,44 @@ namespace GUZ.Core.Manager
         public static int DirectionMode
         {
             get => PlayerPrefs.GetInt(Constants.PlayerPrefDirectionMode, _directionModeCamera);
-            set => PlayerPrefs.SetInt(Constants.PlayerPrefDirectionMode, value);
-        }    
-        
+            set
+            {
+                PlayerPrefs.SetInt(Constants.PlayerPrefDirectionMode, value);
+                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefDirectionMode, DirectionMode);
+            }
+        }
+
         public static bool MovementDirectionCamera
         {
             get => PlayerPrefs.GetInt(Constants.PlayerPrefDirectionMode, _directionModeCamera) == _directionModeCamera;
-            set => PlayerPrefs.SetInt(Constants.PlayerPrefDirectionMode, value ? _directionModeCamera : -1);
+            set
+            {
+                PlayerPrefs.SetInt(Constants.PlayerPrefDirectionMode, value ? _directionModeCamera : -1);
+                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefDirectionMode, MovementDirectionCamera);
+            }
         }
 
         public static bool MovementDirectionLeftController
         {
             get => PlayerPrefs.GetInt(Constants.PlayerPrefDirectionMode, _directionModeCamera) == _directionModeLeftController;
-            set => PlayerPrefs.SetInt(Constants.PlayerPrefDirectionMode, value ? _directionModeLeftController : -1);
+            set
+            {
+                PlayerPrefs.SetInt(Constants.PlayerPrefDirectionMode, value ? _directionModeLeftController : -1);
+                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefDirectionMode, MovementDirectionLeftController);
+            }
         }
-        
+
         public static bool MovementDirectionRightController
         {
             get => PlayerPrefs.GetInt(Constants.PlayerPrefDirectionMode, _directionModeCamera) == _directionModeRightController;
-            set => PlayerPrefs.SetInt(Constants.PlayerPrefDirectionMode, value ? _directionModeRightController : -1);
+            set
+            {
+                PlayerPrefs.SetInt(Constants.PlayerPrefDirectionMode, value ? _directionModeRightController : -1);
+                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefDirectionMode, MovementDirectionRightController);
+            }
         }
-        
-        
+
+
         /**
          * Turn settings
          */
@@ -57,38 +76,61 @@ namespace GUZ.Core.Manager
         public static int RotationType
         {
             get => PlayerPrefs.GetInt(Constants.PlayerPrefRotationType, _rotationTypeSnap);
-            set => PlayerPrefs.SetInt(Constants.PlayerPrefRotationType, value);
+            set
+            {
+                PlayerPrefs.SetInt(Constants.PlayerPrefRotationType, value);
+                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefRotationType, RotationType);
+            }
         }
-        
-        
+
         public static bool SmoothRotation
         {
             get => PlayerPrefs.GetInt(Constants.PlayerPrefRotationType, _rotationTypeSnap) == _rotationTypeSmooth;
-            set => PlayerPrefs.SetInt(Constants.PlayerPrefRotationType, value ? _rotationTypeSmooth : _rotationTypeSnap);
+            set
+            {
+                PlayerPrefs.SetInt(Constants.PlayerPrefRotationType, value ? _rotationTypeSmooth : _rotationTypeSnap);
+                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefRotationType, SmoothRotation);
+            }
         }
-        
+
         public static bool SnapRotation
         {
             get => PlayerPrefs.GetInt(Constants.PlayerPrefRotationType, _rotationTypeSnap) == _rotationTypeSnap;
-            set => PlayerPrefs.SetInt(Constants.PlayerPrefRotationType, value ? _rotationTypeSnap : _rotationTypeSmooth);
+            set
+            {
+                PlayerPrefs.SetInt(Constants.PlayerPrefRotationType, value ? _rotationTypeSnap : _rotationTypeSmooth);
+                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefRotationType, SnapRotation);
+            }
         }
-        
+
         public static int SmoothRotationSpeed
         {
             get => PlayerPrefs.GetInt(Constants.PlayerPrefSmoothRotationSpeed, _defaultSmoothRotationSpeed);
-            set => PlayerPrefs.SetInt(Constants.PlayerPrefSmoothRotationSpeed, value);
+            set
+            {
+                PlayerPrefs.SetInt(Constants.PlayerPrefSmoothRotationSpeed, value);
+                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefSmoothRotationSpeed, SmoothRotationSpeed);
+            }
         }
 
         public static int SnapRotationAmount
         {
             get => PlayerPrefs.GetInt(Constants.PlayerPrefSnapRotationAmount, _defaultSnapRotationAmount);
-            set => PlayerPrefs.SetInt(Constants.PlayerPrefSnapRotationAmount, value);
+            set
+            {
+                PlayerPrefs.SetInt(Constants.PlayerPrefSnapRotationAmount, value);
+                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefSnapRotationAmount, SnapRotationAmount);
+            }
         }
-        
+
         public static bool ItemCollisionWhileDragged
         {
             get => Convert.ToBoolean(PlayerPrefs.GetInt(Constants.PlayerPrefItemCollisionWhileDragged, Convert.ToInt32(_defaultItemCollisionWhileDragged)));
-            set => PlayerPrefs.SetInt(Constants.PlayerPrefItemCollisionWhileDragged, Convert.ToInt32(value));
+            set
+            {
+                PlayerPrefs.SetInt(Constants.PlayerPrefItemCollisionWhileDragged, Convert.ToInt32(value));
+                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefItemCollisionWhileDragged, ItemCollisionWhileDragged);
+            }
         }
     }
 }

--- a/Assets/Gothic-UnZENity-Core/Scripts/Manager/PlayerPrefsManager.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Manager/PlayerPrefsManager.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using GUZ.Core.Globals;
 using UnityEngine;
-using UnityEngine.Events;
 
 namespace GUZ.Core.Manager
 {
     public class PlayerPrefsManager
     {
-        public static UnityEvent<string, object> PlayerPrefsUpdated = new();
-
         // Movement - Direction
         private const int _directionModeCamera = 0;
         private const int _directionModeLeftController = 1;
@@ -34,7 +31,7 @@ namespace GUZ.Core.Manager
             set
             {
                 PlayerPrefs.SetInt(Constants.PlayerPrefDirectionMode, value);
-                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefDirectionMode, DirectionMode);
+                GlobalEventDispatcher.PlayerPrefUpdated.Invoke(Constants.PlayerPrefDirectionMode, DirectionMode);
             }
         }
 
@@ -44,7 +41,7 @@ namespace GUZ.Core.Manager
             set
             {
                 PlayerPrefs.SetInt(Constants.PlayerPrefDirectionMode, value ? _directionModeCamera : -1);
-                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefDirectionMode, MovementDirectionCamera);
+                GlobalEventDispatcher.PlayerPrefUpdated.Invoke(Constants.PlayerPrefDirectionMode, MovementDirectionCamera);
             }
         }
 
@@ -54,7 +51,7 @@ namespace GUZ.Core.Manager
             set
             {
                 PlayerPrefs.SetInt(Constants.PlayerPrefDirectionMode, value ? _directionModeLeftController : -1);
-                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefDirectionMode, MovementDirectionLeftController);
+                GlobalEventDispatcher.PlayerPrefUpdated.Invoke(Constants.PlayerPrefDirectionMode, MovementDirectionLeftController);
             }
         }
 
@@ -64,7 +61,7 @@ namespace GUZ.Core.Manager
             set
             {
                 PlayerPrefs.SetInt(Constants.PlayerPrefDirectionMode, value ? _directionModeRightController : -1);
-                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefDirectionMode, MovementDirectionRightController);
+                GlobalEventDispatcher.PlayerPrefUpdated.Invoke(Constants.PlayerPrefDirectionMode, MovementDirectionRightController);
             }
         }
 
@@ -79,7 +76,7 @@ namespace GUZ.Core.Manager
             set
             {
                 PlayerPrefs.SetInt(Constants.PlayerPrefRotationType, value);
-                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefRotationType, RotationType);
+                GlobalEventDispatcher.PlayerPrefUpdated.Invoke(Constants.PlayerPrefRotationType, RotationType);
             }
         }
 
@@ -89,7 +86,7 @@ namespace GUZ.Core.Manager
             set
             {
                 PlayerPrefs.SetInt(Constants.PlayerPrefRotationType, value ? _rotationTypeSmooth : _rotationTypeSnap);
-                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefRotationType, SmoothRotation);
+                GlobalEventDispatcher.PlayerPrefUpdated.Invoke(Constants.PlayerPrefRotationType, SmoothRotation);
             }
         }
 
@@ -99,7 +96,7 @@ namespace GUZ.Core.Manager
             set
             {
                 PlayerPrefs.SetInt(Constants.PlayerPrefRotationType, value ? _rotationTypeSnap : _rotationTypeSmooth);
-                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefRotationType, SnapRotation);
+                GlobalEventDispatcher.PlayerPrefUpdated.Invoke(Constants.PlayerPrefRotationType, SnapRotation);
             }
         }
 
@@ -109,7 +106,7 @@ namespace GUZ.Core.Manager
             set
             {
                 PlayerPrefs.SetInt(Constants.PlayerPrefSmoothRotationSpeed, value);
-                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefSmoothRotationSpeed, SmoothRotationSpeed);
+                GlobalEventDispatcher.PlayerPrefUpdated.Invoke(Constants.PlayerPrefSmoothRotationSpeed, SmoothRotationSpeed);
             }
         }
 
@@ -119,7 +116,7 @@ namespace GUZ.Core.Manager
             set
             {
                 PlayerPrefs.SetInt(Constants.PlayerPrefSnapRotationAmount, value);
-                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefSnapRotationAmount, SnapRotationAmount);
+                GlobalEventDispatcher.PlayerPrefUpdated.Invoke(Constants.PlayerPrefSnapRotationAmount, SnapRotationAmount);
             }
         }
 
@@ -129,7 +126,7 @@ namespace GUZ.Core.Manager
             set
             {
                 PlayerPrefs.SetInt(Constants.PlayerPrefItemCollisionWhileDragged, Convert.ToInt32(value));
-                PlayerPrefsUpdated.Invoke(Constants.PlayerPrefItemCollisionWhileDragged, ItemCollisionWhileDragged);
+                GlobalEventDispatcher.PlayerPrefUpdated.Invoke(Constants.PlayerPrefItemCollisionWhileDragged, ItemCollisionWhileDragged);
             }
         }
     }

--- a/Assets/Gothic-UnZENity-Core/Scripts/Player/Menu/MenuManager.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/Player/Menu/MenuManager.cs
@@ -23,7 +23,6 @@ namespace GUZ.Core.Player.Menu
         public AudioMixerHandler MusicVolumeHandler;
         public AudioMixerHandler SoundEffectsVolumeHandler;
 
-        public GameObject MainMenuImageBackground;
         public GameObject MainMenuBackground;
         public GameObject MainMenuSaveLoadBackground;
         public GameObject MainMenuText;
@@ -37,8 +36,6 @@ namespace GUZ.Core.Player.Menu
 
         public void SetMaterials()
         {
-            MainMenuImageBackground.GetComponent<MeshRenderer>().material =
-                GameGlobals.Textures.MainMenuImageBackgroundMaterial;
             MainMenuSaveLoadBackground.GetComponent<MeshRenderer>().material =
                 GameGlobals.Textures.MainMenuSaveLoadBackgroundMaterial;
             MainMenuBackground.GetComponent<MeshRenderer>().material = GameGlobals.Textures.MainMenuBackgroundMaterial;

--- a/Assets/Gothic-UnZENity-Core/Scripts/PrefabType.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/PrefabType.cs
@@ -23,6 +23,8 @@ namespace GUZ.Core
         VobSound,
         VobSoundDaytime,
         VobLadder,
+
+        MainMenu,
         XRDeviceSimulator,
         StoryIntroduceChapter
     }
@@ -52,6 +54,8 @@ namespace GUZ.Core
                 PrefabType.VobSound => "Prefabs/Vobs/zCVobSound",
                 PrefabType.VobSoundDaytime => "Prefabs/Vobs/zCVobSoundDaytime",
                 PrefabType.VobLadder => "Prefabs/Vobs/oCMobLadder",
+
+                PrefabType.MainMenu => "Prefabs/Menus/MainMenu",
                 PrefabType.XRDeviceSimulator => "Prefabs/VRPlayer/XR Device Simulator",
                 PrefabType.StoryIntroduceChapter => "Prefabs/Story/IntroduceChapter",
                 _ => throw new Exception($"Enum value {type} not yet defined.")

--- a/Assets/Gothic-UnZENity-Core/Scripts/UI/MainMenu/MainMenuSceneHandler.cs
+++ b/Assets/Gothic-UnZENity-Core/Scripts/UI/MainMenu/MainMenuSceneHandler.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+namespace GUZ.Core.UI.MainMenu
+{
+    /// <summary>
+    /// Specific manager for MainMenu.unity scene tasks only.
+    /// </summary>
+    public class MainMenuSceneHandler : MonoBehaviour
+    {
+        [SerializeField]
+        private GameObject _mainMenuImageBackground;
+
+        private void Start()
+        {
+            _mainMenuImageBackground.GetComponent<MeshRenderer>().material =
+                GameGlobals.Textures.MainMenuImageBackgroundMaterial;
+        }
+
+    }
+}

--- a/Assets/Gothic-UnZENity-Core/Scripts/UI/MainMenu/MainMenuSceneHandler.cs.meta
+++ b/Assets/Gothic-UnZENity-Core/Scripts/UI/MainMenu/MainMenuSceneHandler.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e421d90117014e11a76cc17dd4c7a4c2
+timeCreated: 1724845744

--- a/Assets/Gothic-UnZENity-HVR/Resources/HVR/Prefabs/VRPlayer.prefab
+++ b/Assets/Gothic-UnZENity-HVR/Resources/HVR/Prefabs/VRPlayer.prefab
@@ -5794,6 +5794,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: TechDemoXRRigOpenXR
       objectReference: {fileID: 0}
+    - target: {fileID: 7499251380841772863, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+      propertyPath: Player
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7499251380841772863, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+      propertyPath: TeleportableLayers.m_Bits
+      value: 1049335
+      objectReference: {fileID: 0}
     - target: {fileID: 7793171865378227443, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
       propertyPath: Released.m_PersistentCalls.m_Calls.Array.size
       value: 1
@@ -6044,9 +6052,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 5939876337207847242, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+    - {fileID: 7486009837194656685, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 7486009837194656688, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+      insertIndex: 0
+      addedObject: {fileID: 3339919101757545515}
     m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7486009837194656689, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+      insertIndex: 2
+      addedObject: {fileID: 8604294565651286147}
     - targetCorrespondingSourceObject: {fileID: 7486009837194656689, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
       insertIndex: 5
       addedObject: {fileID: 6717938044841316945}
@@ -6060,6 +6075,72 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 1991208515551361440}
   m_SourcePrefab: {fileID: 100100000, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+--- !u!114 &2664272210811367193 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3994470512131935389, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+  m_PrefabInstance: {fileID: 1411404257910760324}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de1e5b754bd6d9241a88e889575193b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3365186572694181680 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4406169610389779636, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+  m_PrefabInstance: {fileID: 1411404257910760324}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de1e5b754bd6d9241a88e889575193b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4453654672246159007 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3339665285992092955, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+  m_PrefabInstance: {fileID: 1411404257910760324}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf09ab92679f4a018fef9dba9dc51697, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4547154782527327296 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3210201902041804740, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+  m_PrefabInstance: {fileID: 1411404257910760324}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce026d01d1f538044a048be125f5a85e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5441288883928642958 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6346987878268507658, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+  m_PrefabInstance: {fileID: 1411404257910760324}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce026d01d1f538044a048be125f5a85e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5706833214249002317 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6675722384655828681, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+  m_PrefabInstance: {fileID: 1411404257910760324}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d3af8af6dc3ac2441aed4d9bf1ff4be2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6214136005849584828 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5020206764174325560, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
@@ -6077,11 +6158,92 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d33b9b45f9124f6b8afdb52a10613db0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &7420691353957554192 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8461638943674039188, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+  m_PrefabInstance: {fileID: 1411404257910760324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &8391885030032322550 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7486009837306776690, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+  m_PrefabInstance: {fileID: 1411404257910760324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &8391885030387849268 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7486009837194656688, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+  m_PrefabInstance: {fileID: 1411404257910760324}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &8391885030387849269 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7486009837194656689, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
   m_PrefabInstance: {fileID: 1411404257910760324}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &8604294565651286147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8391885030387849269}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4bc893f9e51442baded9f35750db166, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CanJump: 1
+  CanSteerWhileJumping: 1
+  CanSprint: 1
+  CanCrouch: 1
+  DirectionStyle: 0
+  InitialHMDAdjustment: 1
+  GroundedLayerMask:
+    serializedVersion: 2
+    m_Bits: 0
+  GroundedDistance: 0.02
+  GroundedRadiusFactor: 0.5
+  MinHeight: 0.3
+  InstantAcceleration: 1
+  Acceleration: 15
+  Deacceleration: 15
+  MoveSpeed: 1.5
+  SprintAcceleration: 20
+  RunSpeed: 3.5
+  Gravity: 5
+  MaxFallSpeed: 5
+  JumpVelocity: 2
+  DoubleClickThreshold: 0.25
+  RotationType: 0
+  SmoothTurnSpeed: 250
+  SmoothTurnThreshold: 0.1
+  SnapAmount: 45
+  SnapThreshold: 0.75
+  RotateWhileTeleportAiming: 0
+  CrouchMinHeight: 1.2
+  CrouchHeight: 0.7
+  CrouchSpeed: 1.5
+  Camera: {fileID: 8391885030032322550}
+  NeckPivot: {fileID: 7420691353957554192}
+  Root: {fileID: 8391885031977683603}
+  FloorOffset: {fileID: 8391885032028637681}
+  LeftControllerTransform: {fileID: 8391885031598806333}
+  RightControllerTransform: {fileID: 8391885031051259193}
+  CameraRig: {fileID: 8577711515293921465}
+  LeftHand: {fileID: 4547154782527327296}
+  RightHand: {fileID: 5441288883928642958}
+  LeftJointHand: {fileID: 3365186572694181680}
+  RightJointHand: {fileID: 2664272210811367193}
+  ScreenFader: {fileID: 4453654672246159007}
+  HeadCollision: {fileID: 5706833214249002317}
+  HeadCollisionFadeSpeed: 3
+  HeadCollisionPushesBack: 1
+  LimitHeadDistance: 1
+  MaxLean: 0.4
+  FadeFromLean: 1
+  MouseTurning: 0
+  MouseSensitivityX: 1
+  IsGrounded: 0
+  _actualVelocity: 0
+  MainMenu: {fileID: 9123438784457805594}
 --- !u!114 &6717938044841316945
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6149,6 +6311,12 @@ MonoBehaviour:
   UseWASD: 0
   IsMouseDown: 0
   MouseAxis: {x: 0, y: 0}
+  IsMenuActivated: 0
+  MenuState:
+    Active: 0
+    JustActivated: 0
+    JustDeactivated: 0
+    Value: 0
 --- !u!114 &7174930359443231006
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6284,11 +6452,37 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!4 &8391885031051259193 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7486009837755879101, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+  m_PrefabInstance: {fileID: 1411404257910760324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &8391885031598806333 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7486009836797425337, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+  m_PrefabInstance: {fileID: 1411404257910760324}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &8391885031977683603 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7486009836569372951, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
   m_PrefabInstance: {fileID: 1411404257910760324}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &8391885032028637681 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7486009836652636789, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+  m_PrefabInstance: {fileID: 1411404257910760324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8577711515293921465 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7249801016317678397, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
+  m_PrefabInstance: {fileID: 1411404257910760324}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bccf1e5bfe81ea449669046dd363b91, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1428415035291493033
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6412,4 +6606,71 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 3543920068253889183, guid: 261cd02cb70b9844d9a9ba0254a17b12, type: 3}
   m_PrefabInstance: {fileID: 2358216257828498269}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3333539299832117945
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8391885030387849268}
+    m_Modifications:
+    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5827635276208223651, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+      propertyPath: m_Name
+      value: MainMenu
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+--- !u!4 &3339919101757545515 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+  m_PrefabInstance: {fileID: 3333539299832117945}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &9123438784457805594 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5827635276208223651, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
+  m_PrefabInstance: {fileID: 3333539299832117945}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Gothic-UnZENity-HVR/Resources/HVR/Prefabs/VRPlayer.prefab
+++ b/Assets/Gothic-UnZENity-HVR/Resources/HVR/Prefabs/VRPlayer.prefab
@@ -6190,7 +6190,7 @@ MonoBehaviour:
   InitialHMDAdjustment: 1
   GroundedLayerMask:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 1
   GroundedDistance: 0.02
   GroundedRadiusFactor: 0.5
   MinHeight: 0.3
@@ -6235,7 +6235,7 @@ MonoBehaviour:
   MouseSensitivityX: 1
   IsGrounded: 0
   _actualVelocity: 0
-  _mainMenu: {fileID: 0}
+  MainMenu: {fileID: 0}
 --- !u!114 &6717938044841316945
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Gothic-UnZENity-HVR/Resources/HVR/Prefabs/VRPlayer.prefab
+++ b/Assets/Gothic-UnZENity-HVR/Resources/HVR/Prefabs/VRPlayer.prefab
@@ -6054,10 +6054,7 @@ PrefabInstance:
     - {fileID: 5939876337207847242, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
     - {fileID: 7486009837194656685, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 7486009837194656688, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
-      insertIndex: 0
-      addedObject: {fileID: 3339919101757545515}
+    m_AddedGameObjects: []
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 7486009837194656689, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
       insertIndex: 2
@@ -6168,11 +6165,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7486009837306776690, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
   m_PrefabInstance: {fileID: 1411404257910760324}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &8391885030387849268 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7486009837194656688, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
-  m_PrefabInstance: {fileID: 1411404257910760324}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &8391885030387849269 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7486009837194656689, guid: a0de35f4e16efb54ba0281586c17416f, type: 3}
@@ -6243,7 +6235,7 @@ MonoBehaviour:
   MouseSensitivityX: 1
   IsGrounded: 0
   _actualVelocity: 0
-  MainMenu: {fileID: 9123438784457805594}
+  _mainMenu: {fileID: 0}
 --- !u!114 &6717938044841316945
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6606,71 +6598,4 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 3543920068253889183, guid: 261cd02cb70b9844d9a9ba0254a17b12, type: 3}
   m_PrefabInstance: {fileID: 2358216257828498269}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &3333539299832117945
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 8391885030387849268}
-    m_Modifications:
-    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5827635276208223651, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
-      propertyPath: m_Name
-      value: MainMenu
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
---- !u!4 &3339919101757545515 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7559068981978770, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
-  m_PrefabInstance: {fileID: 3333539299832117945}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &9123438784457805594 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5827635276208223651, guid: b2f7ec490b212544e97a98adc4cb9d50, type: 3}
-  m_PrefabInstance: {fileID: 3333539299832117945}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerController.cs
+++ b/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerController.cs
@@ -1,3 +1,4 @@
+using GUZ.Core;
 using GUZ.Core.Manager;
 using HurricaneVR.Framework.Core.Player;
 using MyBox;
@@ -17,7 +18,7 @@ namespace GUZ.HVR.Components
 
         private void Start()
         {
-            PlayerPrefsManager.PlayerPrefsUpdated.AddListener(OnPlayerPrefsUpdated);
+            GlobalEventDispatcher.PlayerPrefUpdated.AddListener(OnPlayerPrefsUpdated);
         }
 
         protected override void Update()
@@ -33,7 +34,7 @@ namespace GUZ.HVR.Components
 
         private void OnDestroy()
         {
-            PlayerPrefsManager.PlayerPrefsUpdated.RemoveListener(OnPlayerPrefsUpdated);
+            GlobalEventDispatcher.PlayerPrefUpdated.RemoveListener(OnPlayerPrefsUpdated);
         }
 
         /// <summary>

--- a/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerController.cs
+++ b/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerController.cs
@@ -22,6 +22,8 @@ namespace GUZ.HVR.Components
 
         protected override void Update()
         {
+            base.Update();
+
             if (_guzInputs.IsMenuActivated && IsGameScene())
             {
                 // Toggle visibility

--- a/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerController.cs
+++ b/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerController.cs
@@ -1,6 +1,9 @@
+using GUZ.Core.Manager;
 using HurricaneVR.Framework.Core.Player;
 using MyBox;
 using UnityEngine;
+using UnityEngine.SceneManagement;
+using Constants = GUZ.Core.Globals.Constants;
 
 namespace GUZ.HVR.Components
 {
@@ -9,16 +12,78 @@ namespace GUZ.HVR.Components
         private GUZHVRPlayerInputs _guzInputs => (GUZHVRPlayerInputs)Inputs;
 
         [Separator("GUZ - Settings")]
+        [SerializeField]
         public GameObject MainMenu;
+
+        private void Start()
+        {
+            PlayerPrefsManager.PlayerPrefsUpdated.AddListener(OnPlayerPrefsUpdated);
+        }
 
         protected override void Update()
         {
-            if (_guzInputs.IsMenuActivated)
+            if (_guzInputs.IsMenuActivated && IsGameScene())
             {
                 // Toggle visibility
                 MainMenu.SetActive(!MainMenu.activeSelf);
-                Debug.Log("Menu activated");
             }
+        }
+
+        private void OnDestroy()
+        {
+            PlayerPrefsManager.PlayerPrefsUpdated.RemoveListener(OnPlayerPrefsUpdated);
+        }
+
+        /// <summary>
+        /// Used in game scenes where you play the game (world.unity, ...)
+        /// </summary>
+        public void SetNormalControls()
+        {
+            DirectionStyle = (PlayerDirectionMode)PlayerPrefsManager.DirectionMode;
+            RotationType = (RotationType)PlayerPrefsManager.RotationType;
+            SnapAmount = PlayerPrefsManager.SnapRotationAmount;
+            SmoothTurnSpeed = PlayerPrefsManager.SmoothRotationSpeed;
+        }
+
+        /// <summary>
+        /// Disable certain actions to keep player stuck in current position.
+        /// </summary>
+        public void SetMainMenuControls()
+        {
+            // Disable physics
+            Gravity = 0f;
+            MaxFallSpeed = 0f;
+
+            // Disable movement
+            MovementEnabled = false;
+            MoveSpeed = 0f;
+            RunSpeed = 0f;
+
+            // Disable rotation
+            RotationEnabled = false;
+            SmoothTurnSpeed = 0f;
+            SnapAmount = 0f;
+        }
+
+        private void OnPlayerPrefsUpdated(string preferenceKey, object value)
+        {
+            // Just update everything.
+            SetNormalControls();
+        }
+
+        /// <summary>
+        /// Game scenes are all the ones where we play. Aka !=MainMenu, !=Loadings, ...
+        /// </summary>
+        private bool IsGameScene()
+        {
+            var activeSceneName = SceneManager.GetActiveScene().name;
+
+            return activeSceneName switch
+            {
+                Constants.SceneMainMenu => false,
+                Constants.SceneLoading => false,
+                _ => true
+            };
         }
     }
 }

--- a/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerController.cs
+++ b/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerController.cs
@@ -1,0 +1,24 @@
+using HurricaneVR.Framework.Core.Player;
+using MyBox;
+using UnityEngine;
+
+namespace GUZ.HVR.Components
+{
+    public class GUZHVRPlayerController : HVRPlayerController
+    {
+        private GUZHVRPlayerInputs _guzInputs => (GUZHVRPlayerInputs)Inputs;
+
+        [Separator("GUZ - Settings")]
+        public GameObject MainMenu;
+
+        protected override void Update()
+        {
+            if (_guzInputs.IsMenuActivated)
+            {
+                // Toggle visibility
+                MainMenu.SetActive(!MainMenu.activeSelf);
+                Debug.Log("Menu activated");
+            }
+        }
+    }
+}

--- a/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerController.cs.meta
+++ b/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerController.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f4bc893f9e51442baded9f35750db166
+timeCreated: 1724836797

--- a/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerInputs.cs
+++ b/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerInputs.cs
@@ -14,16 +14,17 @@ namespace GUZ.HVR.Components
 
         protected override void UpdateInput()
         {
+            base.UpdateInput();
+
             if (!UpdateInputs)
             {
                 return;
             }
 
             IsMenuActivated = GetMenuActivated();
+
+            ResetState(ref MenuState);
             SetState(ref MenuState, IsMenuActivated);
-
-            base.UpdateInput();
-
         }
 
         private bool GetMenuActivated()

--- a/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerInputs.cs
+++ b/Assets/Gothic-UnZENity-HVR/Scripts/Components/GUZHVRPlayerInputs.cs
@@ -1,10 +1,51 @@
 ﻿using HurricaneVR.Framework.ControllerInput;
+using HurricaneVR.Framework.Shared;
+using MyBox;
 using UnityEngine.InputSystem;
 
 namespace GUZ.HVR.Components
 {
     public class GUZHVRPlayerInputs : HVRPlayerInputs
     {
+        [Separator("GUZ - Settings")]
+        public bool IsMenuActivated;
+        public HVRButtonState MenuState;
+
+
+        protected override void UpdateInput()
+        {
+            if (!UpdateInputs)
+            {
+                return;
+            }
+
+            IsMenuActivated = GetMenuActivated();
+            SetState(ref MenuState, IsMenuActivated);
+
+            base.UpdateInput();
+
+        }
+
+        private bool GetMenuActivated()
+        {
+            // If HVRSimulator is Active
+            if (UseWASD)
+            {
+                return Keyboard.current[Key.Escape].wasPressedThisFrame;
+            }
+
+            if (HVRInputManager.Instance.LeftController.ControllerType == HVRControllerType.Knuckles)
+            {
+                return HVRController.GetButtonState(HVRHandSide.Left, HVRButtons.TrackPadButton).JustActivated ||
+                       HVRController.GetButtonState(HVRHandSide.Right, HVRButtons.TrackPadButton).JustActivated;
+            }
+            else
+            {
+                return HVRController.GetButtonState(HVRHandSide.Left, HVRButtons.Menu).JustActivated ||
+                       HVRController.GetButtonState(HVRHandSide.Right, HVRButtons.Menu).JustActivated;
+            }
+        }
+
         protected override bool GetIsJumpActivated()
         {
             // If HVRSimulator is active


### PR DESCRIPTION
MainMenu is now usable within normal game.


## Test
* Start game and hit "Menu" button on Quest2 build (not via SteamLink, where this button will open SteamLink menu)
    * (With HVRSimulator, hit _Escape_ like in original G1 to open the menu)
* Alter a value for "Movement" settings.
* Check if this value change is immediately applied to the VR Player

![image](https://github.com/user-attachments/assets/48a50349-bcf2-4260-b1fe-07bb8237bd27)

## Boundaries
* The menu is always in front of us with no smooth movement
* "New Game" isn't working