### PR TITLE
Fix some world chunks getting water shader

### DIFF
--- a/Assets/UnZENity-Core/Scripts/Manager/Scenes/WorldSceneManager.cs
+++ b/Assets/UnZENity-Core/Scripts/Manager/Scenes/WorldSceneManager.cs
@@ -29,49 +29,56 @@ namespace GUZ.Core.Manager.Scenes
         private async Task LoadWorldContentAsync()
         {
             var config = GameGlobals.Config;
-            
-            // 1.
-            // Build the world and vob meshes, populating the texture arrays.
-            // We need to start creating Vobs as we need to calculate world slicing based on amount of lights at a certain space afterwards.
-            if (config.EnableVOBs)
-            {
-                await VobCreator.CreateAsync(config, GameGlobals.Loading, SaveGameManager.CurrentWorldData.Vobs, Constants.VobsPerFrame);
-            }
 
-            // 2.
-            WayNetCreator.Create(config, SaveGameManager.CurrentWorldData);
-
-            // 3.
-            // If the world is visited for the first time, then we need to load Npcs via Wld_InsertNpc()
-            if (config.EnableNpcs)
-            {
-                await NpcCreator.CreateAsync(config, GameGlobals.Loading, Constants.NpcsPerFrame);
-            }
-
-            // 4.
-            if (config.EnableWorldMesh)
-            {
-                await WorldCreator.CreateAsync(config, GameGlobals.Loading);
-            }
-
-            GameGlobals.Sky.InitSky();
-            StationaryLight.InitStationaryLights();
-
-            // World fully loaded
-            ResourceLoader.ReleaseLoadedData();
-            TeleportPlayerToStart();
-
-            // There are many handlers which listen to this event. If any of these fails, we won't get notified without a try-catch.
             try
             {
-                GlobalEventDispatcher.WorldSceneLoaded.Invoke();
-            }
-            catch (Exception e)
-            {
-                Debug.LogError(e);
-            }
+                // 1.
+                // Build the world and vob meshes, populating the texture arrays.
+                // We need to start creating Vobs as we need to calculate world slicing based on amount of lights at a certain space afterwards.
+                if (config.EnableVOBs)
+                {
+                    await VobCreator.CreateAsync(config, GameGlobals.Loading, SaveGameManager.CurrentWorldData.Vobs, Constants.VobsPerFrame);
+                }
 
-            SceneManager.UnloadSceneAsync(Constants.SceneLoading);
+                // 2.
+                WayNetCreator.Create(config, SaveGameManager.CurrentWorldData);
+
+                // 3.
+                // If the world is visited for the first time, then we need to load Npcs via Wld_InsertNpc()
+                if (config.EnableNpcs)
+                {
+                    await NpcCreator.CreateAsync(config, GameGlobals.Loading, Constants.NpcsPerFrame);
+                }
+
+                // 4.
+                if (config.EnableWorldMesh)
+                {
+                    await WorldCreator.CreateAsync(config, GameGlobals.Loading);
+                }
+
+                GameGlobals.Sky.InitSky();
+                StationaryLight.InitStationaryLights();
+
+                // World fully loaded
+                ResourceLoader.ReleaseLoadedData();
+                TeleportPlayerToStart();
+
+                // There are many handlers which listen to this event. If any of these fails, we won't get notified without a try-catch.
+                try
+                {
+                    GlobalEventDispatcher.WorldSceneLoaded.Invoke();
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError(e);
+                }
+
+                SceneManager.UnloadSceneAsync(Constants.SceneLoading);
+            }
+            catch(Exception ex)
+            {
+                Debug.LogException(ex);
+            }
         }
         
         /// <summary>


### PR DESCRIPTION
Turns out that there is a texture that is used both as opaque and as water texture. This fix handles that case correctly by always checking the material group, rather than only checking if a texture name is already included in one of the texture arrays.