### PR TITLE
ugly hotfix Continuous perceptions (even after Diego dialog)

### DIFF
--- a/Assets/UnZENity-Core/Scripts/Globals/Constants.cs
+++ b/Assets/UnZENity-Core/Scripts/Globals/Constants.cs
@@ -129,6 +129,7 @@ namespace GUZ.Core.Globals
 
         public static class DaedalusConst
         {
+            public static int AIVInvincibleKey => GameData.GothicVm.GetSymbolByName("AIV_INVINCIBLE").GetInt(0);
             public static int AIVItemStatusKey => GameData.GothicVm.GetSymbolByName("AIV_ITEMSTATUS").GetInt(0);
             public static int AIVItemFreqKey => GameData.GothicVm.GetSymbolByName("AIV_ITEMFREQ").GetInt(0);
             public static int TAITNone => GameData.GothicVm.GetSymbolByName("TA_IT_NONE").GetInt(0);

--- a/Assets/UnZENity-Core/Scripts/Manager/Culling/NpcMeshCullingManager.cs
+++ b/Assets/UnZENity-Core/Scripts/Manager/Culling/NpcMeshCullingManager.cs
@@ -13,8 +13,6 @@ namespace GUZ.Core.Manager.Culling
         private readonly bool _featureEnableCulling;
         private readonly float _featureCullingDistance;
 
-        public static AiHandler _aiHandler;
-
         // Sphere values to track and update when visible NPCs move.
         private BoundingSphere[] _spheres;
         private readonly Dictionary<int, Transform> _visibleNpcs = new();
@@ -116,13 +114,8 @@ namespace GUZ.Core.Manager.Culling
             if (isInVisibleRange && wasOutOfDistance)
             {
                 // If we walked to an NPC in our game, the NPC will be re-enabled and Routines get reset.
-                _aiHandler = go.GetComponent<AiHandler>();
                 go.GetComponent<AiHandler>().ReEnableNpc();
             }
-        }
-
-        public static void ReEnableNpc(){
-            _aiHandler.ReEnableNpc();
         }
 
         /// <summary>

--- a/Assets/UnZENity-Core/Scripts/Manager/Culling/NpcMeshCullingManager.cs
+++ b/Assets/UnZENity-Core/Scripts/Manager/Culling/NpcMeshCullingManager.cs
@@ -3,6 +3,7 @@ using GUZ.Core.Creator;
 using GUZ.Core.Extensions;
 using GUZ.Core.Npc;
 using GUZ.Core.Npc.Routines;
+using UnityEditor;
 using UnityEngine;
 
 namespace GUZ.Core.Manager.Culling
@@ -11,6 +12,8 @@ namespace GUZ.Core.Manager.Culling
     {
         private readonly bool _featureEnableCulling;
         private readonly float _featureCullingDistance;
+
+        public static AiHandler _aiHandler;
 
         // Sphere values to track and update when visible NPCs move.
         private BoundingSphere[] _spheres;
@@ -113,10 +116,14 @@ namespace GUZ.Core.Manager.Culling
             if (isInVisibleRange && wasOutOfDistance)
             {
                 // If we walked to an NPC in our game, the NPC will be re-enabled and Routines get reset.
+                _aiHandler = go.GetComponent<AiHandler>();
                 go.GetComponent<AiHandler>().ReEnableNpc();
             }
         }
 
+        public static void ReEnableNpc(){
+            _aiHandler.ReEnableNpc();
+        }
 
         /// <summary>
         /// Each frame, we update the visible NPCs' current position.

--- a/Assets/UnZENity-Core/Scripts/Manager/DialogManager.cs
+++ b/Assets/UnZENity-Core/Scripts/Manager/DialogManager.cs
@@ -87,11 +87,6 @@ namespace GUZ.Core.Manager
                     selectableDialogs.Add(dialog);
                 }
 
-                // set AIVAR for invincible while in dialog
-                Debug.Log("StartDialog: set AIV_INVINCIBLE to 1");
-                var foo =MultiTypeCache.NpcCache[GameData.GothicVm.GlobalOther.Index];
-                foo.instance.SetAiVar(Constants.DaedalusConst.AIVInvincibleKey,1);
-
                 selectableDialogs = selectableDialogs.OrderBy(d => d.Nr).ToList();
                 GameContext.DialogAdapter.FillDialog(properties.NpcInstance.Index, selectableDialogs);
                 GameContext.DialogAdapter.ShowDialog(npcGo);
@@ -238,13 +233,9 @@ namespace GUZ.Core.Manager
             GameData.Dialogs.CurrentDialog.Instance = null;
             GameData.Dialogs.CurrentDialog.Options.Clear();
             GameData.Dialogs.IsInDialog = false;
-            
+
 
             GameContext.DialogAdapter.HideDialog();
-            // set AIV_INVINCIBLE to 0
-            Debug.Log("StopDialog: set AIV_INVINCIBLE back to 0");
-            var foo =MultiTypeCache.NpcCache[GameData.GothicVm.GlobalOther.Index];
-            foo.instance.SetAiVar(Constants.DaedalusConst.AIVInvincibleKey,0);
         }
 
         /// <summary>
@@ -294,7 +285,7 @@ namespace GUZ.Core.Manager
                     npcData.properties.Go));
             }
         }
-        
+
         public static bool ExtNpcKnowsInfo(NpcInstance npc, int infoInstance)
         {
             return GameData.KnownDialogInfos.Contains(infoInstance);

--- a/Assets/UnZENity-Core/Scripts/Manager/DialogManager.cs
+++ b/Assets/UnZENity-Core/Scripts/Manager/DialogManager.cs
@@ -8,6 +8,7 @@ using GUZ.Core.Npc;
 using GUZ.Core.Npc.Actions;
 using GUZ.Core.Npc.Actions.AnimationActions;
 using GUZ.Core.Properties;
+using GUZ.Core.Vm;
 using UnityEngine;
 using ZenKit.Daedalus;
 
@@ -35,7 +36,7 @@ namespace GUZ.Core.Manager
         /// initialDialogStarting - We only stop current AI routine if this is the first time the dialog box opens/NPC
         ///     talks important things. Otherwise, the ZS_*_End will get called every time we re-open a dialog in between.
         /// </summary>
-        public static void StartDialog(GameObject npcGo, NpcProperties properties, bool initialDialogStarting)
+        public static void StartDialog(GameObject npcGo, NpcProperties properties, bool initialDialogStarting, bool initiatedByPlayer = false)
         {
             GameData.Dialogs.IsInDialog = true;
 
@@ -59,6 +60,10 @@ namespace GUZ.Core.Manager
                 {
                     Debug.Log("StartDialog: initialDialogStarting");
                     properties.Go.GetComponent<AiHandler>().ClearState(false);
+                    if (initiatedByPlayer)
+                    {
+                        NpcHelper.ExecutePerception(VmGothicEnums.PerceptionType.AssessTalk, properties, properties.NpcInstance, (NpcInstance)GameData.GothicVm.GlobalHero);
+                    }
                 }
                 var selectableDialogs = new List<InfoInstance>();
 

--- a/Assets/UnZENity-Core/Scripts/Manager/DialogManager.cs
+++ b/Assets/UnZENity-Core/Scripts/Manager/DialogManager.cs
@@ -8,8 +8,13 @@ using GUZ.Core.Npc;
 using GUZ.Core.Npc.Actions;
 using GUZ.Core.Npc.Actions.AnimationActions;
 using GUZ.Core.Properties;
+using GUZ.Core.Vm;
+using UnityEditor.SearchService;
 using UnityEngine;
+using UnityEngine.InputSystem.EnhancedTouch;
+using UnityEngine.TextCore;
 using ZenKit.Daedalus;
+using ZenKit.Vobs;
 
 namespace GUZ.Core.Manager
 {
@@ -51,12 +56,15 @@ namespace GUZ.Core.Manager
                 GameData.Dialogs.CurrentDialog.Instance = infoInstance;
                 properties.Go.GetComponent<AiHandler>().ClearState(true);
 
+                // NpcHelper.ExecutePerception(VmGothicEnums.PerceptionType.AssessTalk, properties, properties.NpcInstance, (NpcInstance)GameData.GothicVm.GlobalHero);
+
                 CallMainInformation(properties.NpcInstance.Index, infoInstance);
             }
             else
             {
                 if (initialDialogStarting)
                 {
+                    Debug.Log("StartDialog: initialDialogStarting");
                     properties.Go.GetComponent<AiHandler>().ClearState(false);
                 }
                 var selectableDialogs = new List<InfoInstance>();
@@ -78,6 +86,11 @@ namespace GUZ.Core.Manager
                     // We can now add the dialog
                     selectableDialogs.Add(dialog);
                 }
+
+                // set AIVAR for invincible while in dialog
+                Debug.Log("StartDialog: set AIV_INVINCIBLE to 1");
+                var foo =MultiTypeCache.NpcCache[GameData.GothicVm.GlobalOther.Index];
+                foo.instance.SetAiVar(Constants.DaedalusConst.AIVInvincibleKey,1);
 
                 selectableDialogs = selectableDialogs.OrderBy(d => d.Nr).ToList();
                 GameContext.DialogAdapter.FillDialog(properties.NpcInstance.Index, selectableDialogs);
@@ -225,8 +238,13 @@ namespace GUZ.Core.Manager
             GameData.Dialogs.CurrentDialog.Instance = null;
             GameData.Dialogs.CurrentDialog.Options.Clear();
             GameData.Dialogs.IsInDialog = false;
+            
 
             GameContext.DialogAdapter.HideDialog();
+            // set AIV_INVINCIBLE to 0
+            Debug.Log("StopDialog: set AIV_INVINCIBLE back to 0");
+            var foo =MultiTypeCache.NpcCache[GameData.GothicVm.GlobalOther.Index];
+            foo.instance.SetAiVar(Constants.DaedalusConst.AIVInvincibleKey,0);
         }
 
         /// <summary>

--- a/Assets/UnZENity-Core/Scripts/Manager/DialogManager.cs
+++ b/Assets/UnZENity-Core/Scripts/Manager/DialogManager.cs
@@ -8,13 +8,8 @@ using GUZ.Core.Npc;
 using GUZ.Core.Npc.Actions;
 using GUZ.Core.Npc.Actions.AnimationActions;
 using GUZ.Core.Properties;
-using GUZ.Core.Vm;
-using UnityEditor.SearchService;
 using UnityEngine;
-using UnityEngine.InputSystem.EnhancedTouch;
-using UnityEngine.TextCore;
 using ZenKit.Daedalus;
-using ZenKit.Vobs;
 
 namespace GUZ.Core.Manager
 {
@@ -55,8 +50,6 @@ namespace GUZ.Core.Manager
             {
                 GameData.Dialogs.CurrentDialog.Instance = infoInstance;
                 properties.Go.GetComponent<AiHandler>().ClearState(true);
-
-                // NpcHelper.ExecutePerception(VmGothicEnums.PerceptionType.AssessTalk, properties, properties.NpcInstance, (NpcInstance)GameData.GothicVm.GlobalHero);
 
                 CallMainInformation(properties.NpcInstance.Index, infoInstance);
             }
@@ -233,7 +226,6 @@ namespace GUZ.Core.Manager
             GameData.Dialogs.CurrentDialog.Instance = null;
             GameData.Dialogs.CurrentDialog.Options.Clear();
             GameData.Dialogs.IsInDialog = false;
-
 
             GameContext.DialogAdapter.HideDialog();
         }

--- a/Assets/UnZENity-Core/Scripts/Npc/Actions/AnimationActions/StartProcessInfos.cs
+++ b/Assets/UnZENity-Core/Scripts/Npc/Actions/AnimationActions/StartProcessInfos.cs
@@ -35,6 +35,7 @@ namespace GUZ.Core.Npc.Actions.AnimationActions
                 }
             }
 
+            Debug.Log("StartProcessInfos: " + _dialogId + " " + isInSubDialog);
             DialogManager.StartDialog(NpcGo, Props, false);
         }
     }

--- a/Assets/UnZENity-Core/Scripts/Npc/Actions/AnimationActions/StopProcessInfos.cs
+++ b/Assets/UnZENity-Core/Scripts/Npc/Actions/AnimationActions/StopProcessInfos.cs
@@ -1,9 +1,5 @@
-using GUZ.Core.Globals;
 using GUZ.Core.Manager;
-using GUZ.Core.Manager.Culling;
-using GUZ.Core.Properties;
 using UnityEngine;
-using ZenKit.Daedalus;
 
 namespace GUZ.Core.Npc.Actions.AnimationActions
 {

--- a/Assets/UnZENity-Core/Scripts/Npc/Actions/AnimationActions/StopProcessInfos.cs
+++ b/Assets/UnZENity-Core/Scripts/Npc/Actions/AnimationActions/StopProcessInfos.cs
@@ -1,7 +1,9 @@
+using GUZ.Core.Globals;
 using GUZ.Core.Manager;
 using GUZ.Core.Manager.Culling;
 using GUZ.Core.Properties;
 using UnityEngine;
+using ZenKit.Daedalus;
 
 namespace GUZ.Core.Npc.Actions.AnimationActions
 {
@@ -17,12 +19,9 @@ namespace GUZ.Core.Npc.Actions.AnimationActions
 
         public override void Start()
         {
-            IsFinishedFlag = true;
-            
             DialogManager.StopDialog();
             GameGlobals.Story.SwitchChapterIfPending();
-            // ReEnable NPCs after Dialog is finished. This should probably live somewhere else than NpcMeshCullingManager
-            NpcMeshCullingManager.ReEnableNpc();
+            IsFinishedFlag = true;
         }
     }
 }

--- a/Assets/UnZENity-Core/Scripts/Npc/Actions/AnimationActions/StopProcessInfos.cs
+++ b/Assets/UnZENity-Core/Scripts/Npc/Actions/AnimationActions/StopProcessInfos.cs
@@ -1,4 +1,5 @@
 using GUZ.Core.Manager;
+using GUZ.Core.Manager.Culling;
 using GUZ.Core.Properties;
 using UnityEngine;
 
@@ -20,6 +21,8 @@ namespace GUZ.Core.Npc.Actions.AnimationActions
             
             DialogManager.StopDialog();
             GameGlobals.Story.SwitchChapterIfPending();
+            // ReEnable NPCs after Dialog is finished. This should probably live somewhere else than NpcMeshCullingManager
+            NpcMeshCullingManager.ReEnableNpc();
         }
     }
 }

--- a/Assets/UnZENity-Core/Scripts/Npc/AiHandler.cs
+++ b/Assets/UnZENity-Core/Scripts/Npc/AiHandler.cs
@@ -184,6 +184,13 @@ namespace GUZ.Core.Npc
 
         public void StartRoutine(int action)
         {
+            var actionName = Vm.GetSymbolByIndex(action).Name;
+            if (actionName == "ZS_TALK")
+            {
+                // Logic to resume walking to waypoint would probably go here
+                StartRoutineImmediately(action);
+                return;
+            }
             if (Properties.CurrentLoopState == NpcProperties.LoopState.Loop)
             {
                 // Cache the new action and force the current loop to end

--- a/Assets/UnZENity-Core/Scripts/Npc/AiHandler.cs
+++ b/Assets/UnZENity-Core/Scripts/Npc/AiHandler.cs
@@ -17,6 +17,7 @@ namespace GUZ.Core.Npc
     public class AiHandler : BasePlayerBehaviour, IAnimationCallbacks
     {
         private static DaedalusVm Vm => GameData.GothicVm;
+        private int? _cachedRoutineAction = null;
         private const int _daedalusLoopContinue = 0; // Id taken from a Daedalus constant.
 
         private void Start()
@@ -87,7 +88,7 @@ namespace GUZ.Core.Npc
                             Properties.CurrentLoopState = NpcProperties.LoopState.Start;
                             return;
                         }
-                        
+
                         symbol = Vm.GetSymbolByIndex(Properties.StateLoop);
                         switch (symbol.ReturnType)
                         {
@@ -105,7 +106,7 @@ namespace GUZ.Core.Npc
                         }
 
                         break;
-                    
+
                     case NpcProperties.LoopState.End:
                         if (Properties.StateEnd != 0)
                         {
@@ -125,16 +126,24 @@ namespace GUZ.Core.Npc
                         Properties.CurrentLoopState = NpcProperties.LoopState.AfterEnd;
                         break;
                     case NpcProperties.LoopState.AfterEnd:
-                        // We're done. Restart normal routine.
-                        Properties.CurrentLoopState = NpcProperties.LoopState.Start;
-
-                        // If we're inside another ZS_*_ loop via Ai_StartState(), we will exit it now. If not, we will simply restart current ZS_* routine.
-                        var currentRoutine = gameObject.GetComponent<Routine>().CurrentRoutine;
-                        if (currentRoutine != null)
+                        // Check if we have a cached routine to start
+                        if (_cachedRoutineAction.HasValue)
                         {
-                            StartRoutine(currentRoutine.Action);
+                            StartRoutineImmediately(_cachedRoutineAction.Value);
+                            _cachedRoutineAction = null;
                         }
+                        else
+                        {
+                            // We're done. Restart normal routine.
+                            Properties.CurrentLoopState = NpcProperties.LoopState.Start;
 
+                            // If we're inside another ZS_*_ loop via Ai_StartState(), we will exit it now. If not, we will simply restart current ZS_* routine.
+                            var currentRoutine = gameObject.GetComponent<Routine>().CurrentRoutine;
+                            if (currentRoutine != null)
+                            {
+                                StartRoutine(currentRoutine.Action);
+                            }
+                        }
                         break;
                 }
             }
@@ -161,7 +170,7 @@ namespace GUZ.Core.Npc
             // FIXME - We need to add other active perceptions here:
             //         PERC_ASSESSBODY, PERC_ASSESSITEM, PERC_ASSESSENEMY, PERC_ASSESSFIGHTER
             //         But at best when we test it immediately
-            
+
             // Reset timer if we executed Perceptions.
             Properties.CurrentPerceptionTime = 0f;
         }
@@ -175,15 +184,35 @@ namespace GUZ.Core.Npc
 
         public void StartRoutine(int action)
         {
+            if (Properties.CurrentLoopState == NpcProperties.LoopState.Loop)
+            {
+                // Cache the new action and force the current loop to end
+                _cachedRoutineAction = action;
+            }
+            else
+            {
+                // If we're not in a loop, start the new routine immediately
+                StartRoutineImmediately(action);
+            }
+        }
+
+        public void StartRoutineImmediately(int action)
+        {
             // End original loop first
             // TODO - Calling ClearState(false) was buggy when e.g. Diego dialog "END" was clicked. Then the dialog lines were skipped.
             // if (Properties.CurrentLoopState == NpcProperties.LoopState.Loop)
             // {
             //     // We reuse this function as it is doing what we need.
-            //     ClearState(false);
+            //     ClearState(true);
             // }
 
             var didRoutineChange = Properties.StateStart != action;
+
+            if (didRoutineChange && Vm.GetSymbolByIndex(Properties.StateStart).Name == "ZS_TALK")
+            {
+                Debug.Log($"NPC:{Properties.NpcInstance.Id} new routine after ZS_TALK!! THIS SKIPS ZS_TALK_END");
+                Debug.Log($"Current state is {Vm.GetSymbolByIndex(action).Name} {Properties.CurrentLoopState}");
+            }
 
             Properties.StateStart = action;
 
@@ -210,6 +239,7 @@ namespace GUZ.Core.Npc
             // When we reached end of ZS_*_END, we also call this method. Check if we really altered the routine action or just restarted it.
             if (didRoutineChange)
             {
+                Debug.Log($"Start new routine >{routineSymbol.Name}< on >{Properties.Go.name}<");
                 Properties.StateTime = 0;
             }
         }
@@ -279,7 +309,10 @@ namespace GUZ.Core.Npc
             // Spawn to initial spawn location
             var currentRoutine = gameObject.GetComponent<Routine>().CurrentRoutine;
             if (currentRoutine != null)
+            {
                 gameObject.transform.position = WayNetHelper.GetWayNetPoint(currentRoutine.Waypoint).Position;
+                GameData.WayPoints.TryGetValue(currentRoutine.Waypoint, out Properties.CurrentWayPoint);
+            }
 
             // Animation state handling
             Properties.AnimationQueue.Clear();
@@ -293,7 +326,7 @@ namespace GUZ.Core.Npc
                 Properties.CurrentFreePoint.IsLocked = false;
             }
             Properties.CurrentFreePoint = null;
-            Properties.CurrentWayPoint = null;
+            // Properties.CurrentWayPoint = null;
 
             // CurrentItem handling
             Properties.ItemAnimationState = -1;

--- a/Assets/UnZENity-Core/Scripts/Npc/AiHandler.cs
+++ b/Assets/UnZENity-Core/Scripts/Npc/AiHandler.cs
@@ -198,13 +198,6 @@ namespace GUZ.Core.Npc
 
         public void StartRoutineImmediately(int action)
         {
-            // End original loop first
-            // TODO - Calling ClearState(false) was buggy when e.g. Diego dialog "END" was clicked. Then the dialog lines were skipped.
-            // if (Properties.CurrentLoopState == NpcProperties.LoopState.Loop)
-            // {
-            //     // We reuse this function as it is doing what we need.
-            //     ClearState(true);
-            // }
 
             var didRoutineChange = Properties.StateStart != action;
 

--- a/Assets/UnZENity-VR/Scripts/Components/VRNpc.cs
+++ b/Assets/UnZENity-VR/Scripts/Components/VRNpc.cs
@@ -1,4 +1,5 @@
 ﻿#if GUZ_HVR_INSTALLED
+using GUZ.Core.Caches;
 using GUZ.Core.Globals;
 using GUZ.Core.Manager;
 using GUZ.Core.Properties;
@@ -12,14 +13,19 @@ namespace GUZ.VR.Components
     {
         public void OnGrabbed(HVRGrabberBase grabber, HVRGrabbable grabbable)
         {
-            if (GameData.Dialogs.IsInDialog)
+            var foo = MultiTypeCache.NpcCache[GameData.GothicVm.GlobalOther.Index];
+            var isPlayerInvincible = foo.instance.GetAiVar(Constants.DaedalusConst.AIVInvincibleKey);
+            Debug.Log($"NPC Grabbes: IsInDialog = {GameData.Dialogs.IsInDialog}, AIVInvincible = {isPlayerInvincible}");
+            if (GameData.Dialogs.IsInDialog && isPlayerInvincible == 1)
             {
                 DialogManager.SkipCurrentDialogLine(GetComponent<NpcProperties>());
+                Debug.Log("Skipping current dialog line");
             }
             else
             {
                 // FIXME - We need to call passive Perception Perc_ASSESSTALK rather than starting the dialog this way.
                 DialogManager.StartDialog(gameObject, GetComponent<NpcProperties>(), true);
+                Debug.Log("Starting dialog");
             }
         }
     }

--- a/Assets/UnZENity-VR/Scripts/Components/VRNpc.cs
+++ b/Assets/UnZENity-VR/Scripts/Components/VRNpc.cs
@@ -13,9 +13,8 @@ namespace GUZ.VR.Components
     {
         public void OnGrabbed(HVRGrabberBase grabber, HVRGrabbable grabbable)
         {
-            var foo = MultiTypeCache.NpcCache[GameData.GothicVm.GlobalOther.Index];
-            var isPlayerInvincible = foo.instance.GetAiVar(Constants.DaedalusConst.AIVInvincibleKey);
-            Debug.Log($"NPC Grabbes: IsInDialog = {GameData.Dialogs.IsInDialog}, AIVInvincible = {isPlayerInvincible}");
+            var isPlayerInvincible = MultiTypeCache.NpcCache[GameData.GothicVm.GlobalOther.Index].instance.GetAiVar(Constants.DaedalusConst.AIVInvincibleKey);
+            Debug.Log($"NPC Grabbed: IsInDialog = {GameData.Dialogs.IsInDialog}, AIVInvincible = {isPlayerInvincible}");
             if (GameData.Dialogs.IsInDialog && isPlayerInvincible == 1)
             {
                 DialogManager.SkipCurrentDialogLine(GetComponent<NpcProperties>());

--- a/Assets/UnZENity-VR/Scripts/Components/VRNpc.cs
+++ b/Assets/UnZENity-VR/Scripts/Components/VRNpc.cs
@@ -15,7 +15,7 @@ namespace GUZ.VR.Components
         {
             var isPlayerInvincible = MultiTypeCache.NpcCache[GameData.GothicVm.GlobalOther.Index].instance.GetAiVar(Constants.DaedalusConst.AIVInvincibleKey);
             Debug.Log($"NPC Grabbed: IsInDialog = {GameData.Dialogs.IsInDialog}, AIVInvincible = {isPlayerInvincible}");
-            if (GameData.Dialogs.IsInDialog && isPlayerInvincible == 1)
+            if (GameData.Dialogs.IsInDialog)
             {
                 DialogManager.SkipCurrentDialogLine(GetComponent<NpcProperties>());
                 Debug.Log("Skipping current dialog line");
@@ -23,7 +23,7 @@ namespace GUZ.VR.Components
             else
             {
                 // FIXME - We need to call passive Perception Perc_ASSESSTALK rather than starting the dialog this way.
-                DialogManager.StartDialog(gameObject, GetComponent<NpcProperties>(), true);
+                DialogManager.StartDialog(gameObject, GetComponent<NpcProperties>(), true, true);
                 Debug.Log("Starting dialog");
             }
         }


### PR DESCRIPTION
Without these changes (mostly AIVAR sets and call for ReEnableNpcs) After dialog with Diego other NPCs don't initiate the conversation if it's marked important (i.e. Bloodwyn).

To test:
- Spawn Diego (1), Skip (211), Thorus (200) and Bloodwyn (233)
- Spawn at GameStart
- Diego should start the conversation and proceed as normal in the game.
- Chapter 1 has started
- Walk/Teleport to OC
- Approach Bloodwyn and he should start the conversation with you about his pocket money :D

IMPORTANT: Don't talk to Diego while he's busy with walking back to the Camp!!!! There's something wrong happening with the routine/animation queuing and it will basically softlock any dialogs for the session.

Also not sure if related to this change but:
If we're in a dialog window with an NPC, let's say Thorus, and we pick one of the dialog options.. we need to wait until Thorus finishes his current animation (Wait for him to finish looking around) and only then the hero actually starts the dialog. 