### PR TITLE
Borobongo/stabilizing v2

### DIFF
--- a/Assets/Gothic-Core/Resources/FontAsset/LiberationSans SDF empty.asset
+++ b/Assets/Gothic-Core/Resources/FontAsset/LiberationSans SDF empty.asset
@@ -37,6 +37,25 @@ MonoBehaviour:
     m_TabWidth: 29
   m_Material: {fileID: 5152873236376385906}
   m_SourceFontFileGUID: e3265ab4bf004d28a9537516768c1c75
+  m_CreationSettings:
+    sourceFontFileName: 
+    sourceFontFileGUID: e3265ab4bf004d28a9537516768c1c75
+    faceIndex: 0
+    pointSizeSamplingMode: 0
+    pointSize: 104
+    padding: 8
+    paddingMode: 1
+    packingMode: 0
+    atlasWidth: 512
+    atlasHeight: 256
+    characterSetSelectionMode: 5
+    characterSequence: 
+    referencedFontAssetGUID: 
+    referencedTextAssetGUID: 
+    fontStyle: 0
+    fontStyleModifier: 0
+    renderMode: 4165
+    includeFontFeatures: 0
   m_SourceFontFile: {fileID: 0}
   m_SourceFontFilePath: 
   m_AtlasPopulationMode: 0
@@ -67,25 +86,6 @@ MonoBehaviour:
     m_MarkToMarkAdjustmentRecords: []
   m_ShouldReimportFontFeatures: 0
   m_FallbackFontAssetTable: []
-  m_CreationSettings:
-    sourceFontFileName: 
-    sourceFontFileGUID: e3265ab4bf004d28a9537516768c1c75
-    faceIndex: 0
-    pointSizeSamplingMode: 0
-    pointSize: 104
-    padding: 8
-    paddingMode: 1
-    packingMode: 0
-    atlasWidth: 512
-    atlasHeight: 256
-    characterSetSelectionMode: 5
-    characterSequence: 
-    referencedFontAssetGUID: 
-    referencedTextAssetGUID: 
-    fontStyle: 0
-    fontStyleModifier: 0
-    renderMode: 4165
-    includeFontFeatures: 0
   m_FontWeightTable:
   - regularTypeface: {fileID: 0}
     italicTypeface: {fileID: 0}
@@ -151,17 +151,15 @@ Texture2D:
   m_ImageContentsHash:
     serializedVersion: 2
     Hash: 00000000000000000000000000000000
-  m_ForcedFallbackFormat: 4
-  m_DownscaleFallback: 0
   m_IsAlphaChannelOptional: 0
-  serializedVersion: 2
+  serializedVersion: 4
   m_Width: 512
   m_Height: 256
   m_CompleteImageSize: 131072
   m_MipsStripped: 0
   m_TextureFormat: 1
   m_MipCount: 1
-  m_IsReadable: 0
+  m_IsReadable: 1
   m_IsPreProcessed: 0
   m_IgnoreMipmapLimit: 0
   m_MipmapLimitGroupName: 
@@ -297,3 +295,4 @@ Material:
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
     - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Assets/Gothic-Core/Resources/Prefabs/UI/StatusBars/StatusBar.prefab
+++ b/Assets/Gothic-Core/Resources/Prefabs/UI/StatusBars/StatusBar.prefab
@@ -225,7 +225,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_VertexColorAlwaysGammaSpace: 1
-  m_AdditionalShaderChannelsFlag: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0

--- a/Assets/Gothic-Core/Scripts/Adapters/Animations/AnimationSystem.cs
+++ b/Assets/Gothic-Core/Scripts/Adapters/Animations/AnimationSystem.cs
@@ -565,13 +565,13 @@ namespace Gothic.Core.Adapters.Animations
                         AttackAnimation = trackInstance.AnimationName;
                         break;
                     case EventType.OptimalFrame:
-                        AttackOptFrame = eventTag.Slots.Item1.Split(' ').Select(i => Convert.ToInt32(i)).ToList();
+                        AttackOptFrame = eventTag.Slots.Item1.Split(' ').Where(s => !string.IsNullOrEmpty(s)).Select(i => Convert.ToInt32(i)).ToList();
                         break;
                     case EventType.HitEnd:
-                        AttackHitEnd = eventTag.Slots.Item1.Split(' ').Select(i => Convert.ToInt32(i)).ToList();
+                        AttackHitEnd = eventTag.Slots.Item1.Split(' ').Where(s => !string.IsNullOrEmpty(s)).Select(i => Convert.ToInt32(i)).ToList();
                         break;
                     case EventType.ComboWindow:
-                        AttackWindowFrames = eventTag.Slots.Item1.Split(' ').Select(i => Convert.ToInt32(i)).ToList();
+                        AttackWindowFrames = eventTag.Slots.Item1.Split(' ').Where(s => !string.IsNullOrEmpty(s)).Select(i => Convert.ToInt32(i)).ToList();
                         break;
                     // Unused. @see: https://gothic-modding-community.github.io/gmc/zengin/anims/events/#def_dir
                     case EventType.HitDirection:

--- a/Assets/Gothic-Core/Scripts/Adapters/Npc/AiHandler.cs
+++ b/Assets/Gothic-Core/Scripts/Adapters/Npc/AiHandler.cs
@@ -334,8 +334,11 @@ namespace Gothic.Core.Adapters.Npc
             var currentRoutine = Properties.RoutineCurrent;
             if (currentRoutine != null)
             {
-                var wpPos = _wayNetService.GetWayNetPoint(currentRoutine.Waypoint).Position;
-                gameObject.transform.position = _npcService.GetFreeAreaAtSpawnPoint(wpPos);
+                var wp = _wayNetService.GetWayNetPoint(currentRoutine.Waypoint);
+                if (wp != null)
+                    gameObject.transform.position = _npcService.GetFreeAreaAtSpawnPoint(wp.Position);
+                else
+                    Logger.LogWarning($"ReEnableNpc: waypoint '{currentRoutine.Waypoint}' not found for {gameObject.name} — NPC will re-enable at current position.", LogCat.NPC);
             }
 
             // Animation state handling

--- a/Assets/Gothic-Core/Scripts/Adapters/Npc/AiHandler.cs
+++ b/Assets/Gothic-Core/Scripts/Adapters/Npc/AiHandler.cs
@@ -79,9 +79,12 @@ namespace Gothic.Core.Adapters.Npc
             if (Properties.AnimationQueue.Count == 0)
             {
                 // We always need to set "self" before executing any Daedalus function.
+                // "other" defaults to hero here so routine states (ZS_*_Loop) have a sensible fallback.
+                // Perception calls (ExecutePerception) override GlobalOther themselves with their own save/restore.
                 if (NpcInstance != null)
                 {
                     Vm.GlobalSelf = NpcInstance;
+                    Vm.GlobalOther = Vm.GlobalHero;
                 }
 
                 DaedalusSymbol loopSymbol;

--- a/Assets/Gothic-Core/Scripts/Adapters/Npc/AiHandler.cs
+++ b/Assets/Gothic-Core/Scripts/Adapters/Npc/AiHandler.cs
@@ -338,7 +338,7 @@ namespace Gothic.Core.Adapters.Npc
                 if (wp != null)
                     gameObject.transform.position = _npcService.GetFreeAreaAtSpawnPoint(wp.Position);
                 else
-                    Logger.LogWarning($"ReEnableNpc: waypoint '{currentRoutine.Waypoint}' not found for {gameObject.name} — NPC will re-enable at current position.", LogCat.NPC);
+                    Logger.LogWarning($"ReEnableNpc: waypoint '{currentRoutine.Waypoint}' not found for {gameObject.name} — NPC will re-enable at current position.", LogCat.Npc);
             }
 
             // Animation state handling

--- a/Assets/Gothic-Core/Scripts/Adapters/Npc/AiHandler.cs
+++ b/Assets/Gothic-Core/Scripts/Adapters/Npc/AiHandler.cs
@@ -254,14 +254,6 @@ namespace Gothic.Core.Adapters.Npc
 
         public void StartRoutine(int action)
         {
-            // End original loop first
-            // TODO - Calling ClearState(false) was buggy when e.g. Diego dialog "END" was clicked. Then the dialog lines were skipped.
-            // if (Properties.CurrentLoopState == NpcProperties.LoopState.Loop)
-            // {
-            //     // We reuse this function as it is doing what we need.
-            //     ClearState(false);
-            // }
-
             var didRoutineChange = Vob.CurrentStateIndex != action;
 
             Vob.LastAiState = Vob.CurrentStateIndex;
@@ -295,6 +287,11 @@ namespace Gothic.Core.Adapters.Npc
             // When we reached end of ZS_*_END, we also call this method. Check if we really altered the routine action or just restarted it.
             if (didRoutineChange)
             {
+                if (Properties.CurrentFreePoint != null)
+                {
+                    Properties.CurrentFreePoint.IsLocked = false;
+                    Properties.CurrentFreePoint = null;
+                }
                 Logger.Log($"Start new routine >{routineSymbol.Name}< on >{Go.transform.parent.name}<", LogCat.Ai);
                 Properties.StateTime = 0;
             }

--- a/Assets/Gothic-Core/Scripts/Domain/Culling/VobMeshCullingDomain.cs
+++ b/Assets/Gothic-Core/Scripts/Domain/Culling/VobMeshCullingDomain.cs
@@ -572,6 +572,11 @@ namespace Gothic.Core.Domain.Culling
                 {
                     var key = _pausedVobsToReenable.Keys.ElementAt(i);
                     var rigidBody = _pausedVobsToReenable[key];
+                    if (rigidBody == null)
+                    {
+                        _pausedVobsToReenable.Remove(key);
+                        continue;
+                    }
                     if (rigidBody.linearVelocity != Vector3.zero)
                     {
                         continue;

--- a/Assets/Gothic-Core/Scripts/Domain/Meshes/Builder/NpcHeadMeshBuilder.cs
+++ b/Assets/Gothic-Core/Scripts/Domain/Meshes/Builder/NpcHeadMeshBuilder.cs
@@ -20,9 +20,14 @@ namespace Gothic.Core.Domain.Meshes.Builder
                 return RootGo;
             }
 
-            var npcContainer = RootGo.GetComponentInParent<NpcLoader>().Npc.GetUserData();
+            var npcContainer = RootGo.GetComponentInParent<NpcLoader>()?.Npc?.GetUserData();
+            if (npcContainer == null)
+            {
+                Logger.LogWarning($"NpcContainer not available during head build for {RootGo.name} — skipping head component setup.", LogCat.Mesh);
+                return RootGo;
+            }
 
-            // Cache it f1or faster use during runtime
+            // Cache it for faster use during runtime
             npcContainer.PrefabProps.Head = headGo.transform;
             npcContainer.PrefabProps.HeadMorph = headGo.AddComponent<HeadMorph>().Inject();
             npcContainer.PrefabProps.HeadMorph.HeadName = npcContainer.Props.BodyData.Head;

--- a/Assets/Gothic-Core/Scripts/Domain/Npc/Actions/AnimationActions/Attack.cs
+++ b/Assets/Gothic-Core/Scripts/Domain/Npc/Actions/AnimationActions/Attack.cs
@@ -32,6 +32,13 @@ namespace Gothic.Core.Domain.Npc.Actions.AnimationActions
 
         public override void Start()
         {
+            if (Vob.GuildTrue < (int)VmGothicEnums.Guild.GIL_SEPERATOR_HUM)
+            {
+                Logger.Log($"AI_Attack() on human NPC (guild={Vob.GuildTrue}) — not yet implemented, skipping.", LogCat.Ai);
+                IsFinishedFlag = true;
+                return;
+            }
+
             var aiFunctionTemplate = FindAiFunctionTemplate();
             _move = VmCacheService.TryGetFightAiData(aiFunctionTemplate, Vob.FightTactic).GetRandomMove();
             StartAttackAction();

--- a/Assets/Gothic-Core/Scripts/Domain/Npc/Actions/AnimationActions/GoToNpc.cs
+++ b/Assets/Gothic-Core/Scripts/Domain/Npc/Actions/AnimationActions/GoToNpc.cs
@@ -6,6 +6,8 @@ namespace Gothic.Core.Domain.Npc.Actions.AnimationActions
 {
     public class GoToNpc : AbstractWalkAnimationAction
     {
+        private const float ConversationDistance = 1.5f;
+
         private Transform _destinationTransform;
 
         public GoToNpc(AnimationAction action, NpcContainer npcContainer) : base(action, npcContainer)
@@ -21,7 +23,11 @@ namespace Gothic.Core.Domain.Npc.Actions.AnimationActions
 
         protected override Vector3 GetWalkDestination()
         {
-            return _destinationTransform.position;
+            var targetPos = _destinationTransform.position;
+            var toTarget = targetPos - NpcGo.transform.position;
+            if (toTarget.sqrMagnitude < 0.001f)
+                return targetPos;
+            return targetPos + toTarget.normalized * -ConversationDistance;
         }
 
 

--- a/Assets/Gothic-Core/Scripts/Domain/Npc/Actions/AnimationActions/GoToWp.cs
+++ b/Assets/Gothic-Core/Scripts/Domain/Npc/Actions/AnimationActions/GoToWp.cs
@@ -33,8 +33,14 @@ namespace Gothic.Core.Domain.Npc.Actions.AnimationActions
             }
 
             // We need to set the route now to ensure base.Start() can check if NPC is already _on_ the final destination.
-            _route = new Stack<DijkstraWaypoint>(WayNetService.FindFastestPath(currentWaypoint.Name,
-                destinationWaypoint.Name));
+            var path = WayNetService.FindFastestPath(currentWaypoint.Name, destinationWaypoint.Name);
+            if (path == null)
+            {
+                IsFinishedFlag = true;
+                return;
+            }
+
+            _route = new Stack<DijkstraWaypoint>(path);
 
             base.Start();
         }

--- a/Assets/Gothic-Core/Scripts/Domain/Vobs/VobInitializerDomain.cs
+++ b/Assets/Gothic-Core/Scripts/Domain/Vobs/VobInitializerDomain.cs
@@ -581,14 +581,18 @@ namespace Gothic.Core.Domain.Vobs
                 if (sfxContainer == null)
                     return null;
 
+                var firstSound = sfxContainer.GetFirstSound();
+                if (firstSound == null)
+                    return null;
+
                 // Instead of decoding nosound.wav which might be decoded incorrectly, just return null.
-                if (sfxContainer.GetFirstSound().File.EqualsIgnoreCase(AudioService.NoSoundName))
+                if (firstSound.File.EqualsIgnoreCase(AudioService.NoSoundName))
                     return null;
 
                 if (sfxContainer.Count > 1)
-                    Logger.LogWarning($"Multiple random elements exist for >{sfxContainer.GetFirstSound().File}< but only first is selected.", LogCat.Audio);
+                    Logger.LogWarning($"Multiple random elements exist for >{firstSound.File}< but only first is selected.", LogCat.Audio);
 
-                clip = _audioService.CreateAudioClip(sfxContainer.GetFirstSound().File);
+                clip = _audioService.CreateAudioClip(firstSound.File);
             }
 
             return clip;

--- a/Assets/Gothic-Core/Scripts/Models/Audio/SfxModel.cs
+++ b/Assets/Gothic-Core/Scripts/Models/Audio/SfxModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Gothic.Core.Logging;
 using Gothic.Core.Services;
 using Gothic.Core.Const;
 using Gothic.Core.Extensions;
@@ -8,6 +9,7 @@ using JetBrains.Annotations;
 using MyBox;
 using Reflex.Attributes;
 using ZenKit.Daedalus;
+using Logger = Gothic.Core.Logging.Logger;
 
 namespace Gothic.Core.Models.Audio
 {
@@ -64,9 +66,10 @@ namespace Gothic.Core.Models.Audio
                 var firstSound = _gameStateService.SfxVm.InitInstance<SoundEffectInstance>(soundKey);
                 sounds.Add(firstSound);
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                // If the key itself doesn't exist, then we don't need to look further.
+                // SFX symbol missing from Gothic's SFX scripts — expected for some broken VOBs (e.g. Wood_Night2 was never defined).
+                Logger.LogWarning($"SFX symbol not found in VM: '{soundKey}' — no sound will play.", LogCat.Audio);
                 _soundEffects = Array.Empty<SoundEffectInstance>();
                 return;
             }

--- a/Assets/Gothic-Core/Scripts/Services/Npc/FightService.cs
+++ b/Assets/Gothic-Core/Scripts/Services/Npc/FightService.cs
@@ -1,11 +1,9 @@
 using Gothic.Core.Adapters.UI.StatusBars;
-using Gothic.Core.Domain.Npc.Actions.AnimationActions;
 using Gothic.Core.Logging;
 using Gothic.Core.Manager;
 using Gothic.Core.Models.Container;
 using Gothic.Core.Models.Vm;
 using Gothic.Core.Services.Config;
-using Gothic.Core.Services.Vm;
 using Gothic.Core.Services.World;
 using Reflex.Attributes;
 using UnityEngine;
@@ -17,7 +15,6 @@ namespace Gothic.Core.Services.Npc
     public class FightService
     {
         [Inject] private AudioService _audioService;
-        [Inject] private VmService _vmService;
         [Inject] private AnimationService _animationService;
         [Inject] private PhysicsService _physicsService;
         [Inject] private NpcHelperService _npcHelperService;
@@ -33,6 +30,9 @@ namespace Gothic.Core.Services.Npc
 
         private void OnHit(NpcContainer attacker, NpcContainer target, Vector3 __)
         {
+            if (target.Props.BodyState == VmGothicEnums.BodyState.BsDead)
+                return;
+
             Logger.Log($"[FightService.OnHit] *** {attacker.Instance.GetName(NpcNameSlot.Slot0)} HIT {target.Instance.GetName(NpcNameSlot.Slot0)}", LogCat.Npc);
             if (OnHitUpdateHealth(attacker, target))
             {
@@ -90,21 +90,21 @@ namespace Gothic.Core.Services.Npc
 
         private void OnDyingChangeAnimation(NpcContainer target)
         {
-            // Stop current (attack) animation.
-            target.Props.CurrentAction.StopImmediately();
+            // Clear pending AI queue and stop all running animations (e.g. s_walk still looping).
+            // Death takes priority over everything — bypass the queue and play directly.
+            target.Props.AnimationQueue.Clear();
+            target.PrefabProps.AnimationSystem.StopAllAnimations();
             _physicsService.DisablePhysicsForNpc(target.PrefabProps);
 
             var animName = _animationService.GetAnimationName(VmGothicEnums.AnimationType.DeadB, target);
-            target.Props.AnimationQueue.Enqueue(new PlayAni(new(animName), target));
+            target.PrefabProps.AnimationSystem.PlayAnimation(animName);
         }
 
         private void OnHitChangeAnimation(NpcContainer target)
         {
-            // Stop current (attack) animation.
-            target.Props.CurrentAction.StopImmediately();
-
+            // Play hurt on top of whatever is currently running — don't interrupt the current action.
             var animName = _animationService.GetAnimationName(VmGothicEnums.AnimationType.StumbleA, target);
-            target.Props.AnimationQueue.Enqueue(new PlayAni(new(animName), target));
+            target.PrefabProps.AnimationSystem.PlayAnimation(animName);
         }
 
         private void OnHitPlaySound(NpcContainer target)

--- a/Assets/Gothic-Core/Scripts/Services/Npc/NpcAiService.cs
+++ b/Assets/Gothic-Core/Scripts/Services/Npc/NpcAiService.cs
@@ -388,9 +388,9 @@ namespace Gothic.Core.Services.Npc
 
         public bool ExtNpcIsDead(NpcInstance npcInstance)
         {
-            // FIXME - We need to implement it properly. Just fixing NPEs for now!
-            // FIXME - e.g. used for PC_Thief_AFTERTROLL_Condition() from Daedalus.
-            return false;
+            // FIXME - BodyState is runtime-only and lost on NPC reload (e.g. world reload respawns the NPC alive).
+            // A permanent death flag needs to be persisted in SaveGame state and checked here instead.
+            return npcInstance.GetUserData()?.Props.BodyState == VmGothicEnums.BodyState.BsDead;
         }
 
         public bool ExtNpcIsInState(NpcInstance npc, int state)

--- a/Assets/Gothic-Core/Scripts/Services/Npc/NpcAiService.cs
+++ b/Assets/Gothic-Core/Scripts/Services/Npc/NpcAiService.cs
@@ -50,12 +50,12 @@ namespace Gothic.Core.Services.Npc
             }
 
             var oldSelf = _gameStateService.GothicVm.GlobalSelf;
+            var oldOther = _gameStateService.GothicVm.GlobalOther;
             var oldVictim = _gameStateService.GothicVm.GlobalVictim;
-            var oldOther = _gameStateService.GothicVm.GlobalVictim;
 
             _gameStateService.GothicVm.GlobalSelf = self;
-            
-            if(other != null)
+
+            if(other != null) 
             {
                 _gameStateService.GothicVm.GlobalOther = other;
             }
@@ -66,10 +66,10 @@ namespace Gothic.Core.Services.Npc
             }
 
             _gameStateService.GothicVm.Call(perceptionFunction);
-            
+
             _gameStateService.GothicVm.GlobalSelf = oldSelf;
+            _gameStateService.GothicVm.GlobalOther = oldOther;
             _gameStateService.GothicVm.GlobalVictim = oldVictim;
-            _gameStateService.GothicVm.GlobalVictim = oldOther;
         }
 
         public void ExtNpcSetPerceptionTime(NpcInstance npc, float time)
@@ -341,8 +341,8 @@ namespace Gothic.Core.Services.Npc
             var npc1Pos = npc1.GetUserData().Go.transform.position;
 
             Vector3 npc2Pos;
-            // If hero
-            if (npc2.Id == 0)
+            // If hero: use camera position (VR head position is most accurate)
+            if (npc2.Index == _gameStateService.GothicVm.GlobalHero?.Index)
             {
                 npc2Pos = Camera.main!.transform.position;
             }
@@ -395,7 +395,7 @@ namespace Gothic.Core.Services.Npc
 
         public bool ExtNpcIsInState(NpcInstance npc, int state)
         {
-            return npc.GetUserData().Vob.CurrentStateIndex == state;
+            return npc.GetUserData()?.Vob.CurrentStateIndex == state;
         }
 
         public bool ExtNpcIsPlayer(NpcInstance npc)

--- a/Assets/Gothic-Core/Scripts/Services/Npc/NpcHelperService.cs
+++ b/Assets/Gothic-Core/Scripts/Services/Npc/NpcHelperService.cs
@@ -152,7 +152,7 @@ namespace Gothic.Core.Services.Npc
                             _gameStateService.GothicVm.GlobalHero!.Index) // if we don't detect player, then skip it
                 .Where(i => specificNpcIndex < 0 ||
                             specificNpcIndex == i.Instance.Index) // Specific NPC is found right now?
-                .Where(i => aiState < 0 || npcVob.CurrentStateIndex == i.Vob.CurrentStateIndex)
+                .Where(i => aiState < 0 || aiState == i.Vob.CurrentStateIndex)
                 .Where(i => guild < 0 || i.Instance.Guild == guild) // check guild
                 .OrderBy(i => Vector3.Distance(i.Go.transform.position, npcPos)) // get nearest
                 .FirstOrDefault();

--- a/Assets/Gothic-Core/Scripts/Services/Npc/NpcInventoryService.cs
+++ b/Assets/Gothic-Core/Scripts/Services/Npc/NpcInventoryService.cs
@@ -137,15 +137,26 @@ namespace Gothic.Core.Services.Npc
 
         public int ExtNpcHasItems(NpcInstance npc, int itemId)
         {
-            var npcVob = npc.GetUserData()!.Vob;
             var itemInstanceName = _gameStateService.GothicVm.GetSymbolByIndex(itemId)!.Name;
-            
-            for (var i = 0; i < npcVob.ItemCount; i++)
+
+            foreach (InvCats cat in System.Enum.GetValues(typeof(InvCats)))
             {
-                if (npcVob.GetItem(i).Name == itemInstanceName)
-                    return npcVob.GetItem(i).Amount;
+                if (cat == InvCats.InvCatMax)
+                    continue;
+                try
+                {
+                    foreach (var item in GetInventoryItems(npc, cat))
+                    {
+                        if (string.Equals(item.Name, itemInstanceName, System.StringComparison.OrdinalIgnoreCase))
+                            return item.Amount;
+                    }
+                }
+                catch
+                {
+                    // Category slot was never initialized for this NPC
+                }
             }
-            
+
             return 0;
         }
         

--- a/Assets/Gothic-Core/Scripts/Services/Player/DialogService.cs
+++ b/Assets/Gothic-Core/Scripts/Services/Player/DialogService.cs
@@ -99,9 +99,12 @@ namespace Gothic.Core.Manager
                     
                     // TODO - Should be outsourced to some VmManager.Call<int> function which sets and resets values.
                     var oldSelf = _gameStateService.GothicVm.GlobalSelf;
+                    var oldOther = _gameStateService.GothicVm.GlobalOther;
                     _gameStateService.GothicVm.GlobalSelf = npcContainer.Instance;
+                    _gameStateService.GothicVm.GlobalOther = _gameStateService.GothicVm.GlobalHero;
                     var conditionResult = _gameStateService.GothicVm.Call<int>(dialog.Condition);
                     _gameStateService.GothicVm.GlobalSelf = oldSelf;
+                    _gameStateService.GothicVm.GlobalOther = oldOther;
 
                     // Dialog condition is false
                     if (conditionResult == 0)
@@ -146,9 +149,12 @@ namespace Gothic.Core.Manager
                 
                 // TODO - Should be outsourced to some VmManager.Call<int> function which sets and resets values.
                 var oldSelf = _gameStateService.GothicVm.GlobalSelf;
+                var oldOther = _gameStateService.GothicVm.GlobalOther;
                 _gameStateService.GothicVm.GlobalSelf = npcContainer.Instance;
+                _gameStateService.GothicVm.GlobalOther = _gameStateService.GothicVm.GlobalHero;
                 var conditionResult = _gameStateService.GothicVm.Call<int>(dialog.Condition);
                 _gameStateService.GothicVm.GlobalSelf = oldSelf;
+                _gameStateService.GothicVm.GlobalOther = oldOther;
 
                 if (conditionResult == 0)
                 {

--- a/Assets/Gothic-Core/Scripts/Services/UI/FontService.cs
+++ b/Assets/Gothic-Core/Scripts/Services/UI/FontService.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Gothic.Core.Const;
 using Gothic.Core.Logging;
@@ -8,6 +10,7 @@ using Reflex.Attributes;
 using TMPro;
 using UnityEngine;
 using UnityEngine.TextCore;
+using ZenKit;
 using Logger = Gothic.Core.Logging.Logger;
 
 namespace Gothic.Core.Services.UI
@@ -30,6 +33,30 @@ namespace Gothic.Core.Services.UI
 
             TMP_Settings.defaultSpriteAsset = DefaultSpriteAsset;
             TMP_Settings.defaultFontAsset = DefaultFont;
+
+            WarmAtlasFromVm();
+        }
+
+        private void WarmAtlasFromVm()
+        {
+            if (DefaultFont == null || _gameStateService.GothicVm == null)
+                return;
+
+            var uniqueChars = new HashSet<char>();
+            foreach (var symbol in _gameStateService.GothicVm.Symbols)
+            {
+                if (symbol.Type != DaedalusDataType.String || symbol.Size == 0) continue;
+                for (ushort i = 0; i < symbol.Size; i++)
+                {
+                    var str = symbol.GetString(i);
+                    if (string.IsNullOrEmpty(str)) continue;
+                    foreach (var c in str)
+                        uniqueChars.Add(c);
+                }
+            }
+
+            DefaultFont.TryAddCharacters(new string(uniqueChars.ToArray()));
+            Logger.Log($"Font atlas pre-warmed with {uniqueChars.Count} unique chars", LogCat.Misc);
         }
 
         [CanBeNull]
@@ -109,13 +136,13 @@ namespace Gothic.Core.Services.UI
             return spriteAsset;
         }
 
-        private Material GetDefaultSpriteMaterial(Texture2D spriteSheet = null)
+        private UnityEngine.Material GetDefaultSpriteMaterial(Texture2D spriteSheet = null)
         {
             ShaderUtilities.GetShaderPropertyIDs();
 
             // Add a new material
             var shader = Constants.ShaderTMPSprite;
-            var tempMaterial = new Material(shader);
+            var tempMaterial = new UnityEngine.Material(shader);
             tempMaterial.SetTexture(ShaderUtilities.ID_MainTex, spriteSheet);
 
             return tempMaterial;

--- a/Assets/Gothic-Core/Scripts/Services/UI/FontService.cs
+++ b/Assets/Gothic-Core/Scripts/Services/UI/FontService.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Gothic.Core.Const;
 using Gothic.Core.Logging;
@@ -10,7 +7,6 @@ using Reflex.Attributes;
 using TMPro;
 using UnityEngine;
 using UnityEngine.TextCore;
-using ZenKit;
 using Logger = Gothic.Core.Logging.Logger;
 
 namespace Gothic.Core.Services.UI
@@ -33,30 +29,6 @@ namespace Gothic.Core.Services.UI
 
             TMP_Settings.defaultSpriteAsset = DefaultSpriteAsset;
             TMP_Settings.defaultFontAsset = DefaultFont;
-
-            WarmAtlasFromVm();
-        }
-
-        private void WarmAtlasFromVm()
-        {
-            if (DefaultFont == null || _gameStateService.GothicVm == null)
-                return;
-
-            var uniqueChars = new HashSet<char>();
-            foreach (var symbol in _gameStateService.GothicVm.Symbols)
-            {
-                if (symbol.Type != DaedalusDataType.String || symbol.Size == 0) continue;
-                for (ushort i = 0; i < symbol.Size; i++)
-                {
-                    var str = symbol.GetString(i);
-                    if (string.IsNullOrEmpty(str)) continue;
-                    foreach (var c in str)
-                        uniqueChars.Add(c);
-                }
-            }
-
-            DefaultFont.TryAddCharacters(new string(uniqueChars.ToArray()));
-            Logger.Log($"Font atlas pre-warmed with {uniqueChars.Count} unique chars", LogCat.Misc);
         }
 
         [CanBeNull]
@@ -136,13 +108,13 @@ namespace Gothic.Core.Services.UI
             return spriteAsset;
         }
 
-        private UnityEngine.Material GetDefaultSpriteMaterial(Texture2D spriteSheet = null)
+        private Material GetDefaultSpriteMaterial(Texture2D spriteSheet = null)
         {
             ShaderUtilities.GetShaderPropertyIDs();
 
             // Add a new material
             var shader = Constants.ShaderTMPSprite;
-            var tempMaterial = new UnityEngine.Material(shader);
+            var tempMaterial = new Material(shader);
             tempMaterial.SetTexture(ShaderUtilities.ID_MainTex, spriteSheet);
 
             return tempMaterial;

--- a/Assets/Gothic-Core/Scripts/Services/Vobs/VobService.cs
+++ b/Assets/Gothic-Core/Scripts/Services/Vobs/VobService.cs
@@ -176,12 +176,19 @@ namespace Gothic.Core.Services.Vobs
                     // }
 
                     var item = _objectsToInitQueue.Dequeue();
-                    
+
                     item.IsLoaded = true;
 
                     // We assume that each loaded VOB is centered at parent=0,0,0.
                     // Should work smoothly until we start lazy loading sub-vobs ;-)
-                    _initializerDomain.InitVob(item.Container.Vob, item.gameObject, default, true);
+                    try
+                    {
+                        _initializerDomain.InitVob(item.Container.Vob, item.gameObject, default, true);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.LogError($"Failed to init VOB {item.name}: {e}", LogCat.Vob);
+                    }
 
                     yield return _frameSkipperService.TrySkipToNextFrameCoroutine();
                 }

--- a/Assets/Gothic-VR/Resources/VR/Prefabs/Player-Elements/BackPack.prefab
+++ b/Assets/Gothic-VR/Resources/VR/Prefabs/Player-Elements/BackPack.prefab
@@ -1293,15 +1293,15 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 6401121504383089494, guid: 4293d805a850fb84885c55f47b7299bd, type: 3}
       propertyPath: m_text
-      value: x/y
+      value: ''
       objectReference: {fileID: 0}
     - target: {fileID: 6401121504383089494, guid: 4293d805a850fb84885c55f47b7299bd, type: 3}
       propertyPath: m_fontAsset
-      value: 
+      value:
       objectReference: {fileID: 11400000, guid: ed34b05229166f3469c21b7208879736, type: 2}
     - target: {fileID: 6401121504383089494, guid: 4293d805a850fb84885c55f47b7299bd, type: 3}
       propertyPath: m_sharedMaterial
-      value: 
+      value:
       objectReference: {fileID: 5152873236376385906, guid: ed34b05229166f3469c21b7208879736, type: 2}
     - target: {fileID: 6401121504383089494, guid: 4293d805a850fb84885c55f47b7299bd, type: 3}
       propertyPath: m_VerticalAlignment
@@ -3692,7 +3692,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 6401121504383089494, guid: 4293d805a850fb84885c55f47b7299bd, type: 3}
       propertyPath: m_text
-      value: '{{CATEGORY}}'
+      value: ''
       objectReference: {fileID: 0}
     - target: {fileID: 6401121504383089494, guid: 4293d805a850fb84885c55f47b7299bd, type: 3}
       propertyPath: m_fontSize

--- a/Assets/Gothic-VR/Resources/VR/Prefabs/Vobs/oCNpc.prefab
+++ b/Assets/Gothic-VR/Resources/VR/Prefabs/Vobs/oCNpc.prefab
@@ -764,6 +764,10 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 2.8
       objectReference: {fileID: 0}
+    - target: {fileID: 2805224566998289421, guid: 6ce7e724ba52cae47a499f87c612cd47, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.02
+      objectReference: {fileID: 0}
     - target: {fileID: 8230739814078363531, guid: 6ce7e724ba52cae47a499f87c612cd47, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5

--- a/Assets/Gothic-VR/Scripts/Adapters/Player/VRBackpack.cs
+++ b/Assets/Gothic-VR/Scripts/Adapters/Player/VRBackpack.cs
@@ -114,6 +114,8 @@ namespace Gothic.VR.Adapters.Player
         public void OnItemPutOutOfHolster(HVRGrabberBase grabber, HVRGrabbable grabbable)
         {
             var vobLoader = grabbable.GetComponentInParent<VobLoader>();
+            if (vobLoader == null)
+                return;
             var vobContainer = vobLoader.Container;
 
             _playerService.RemoveItem(vobContainer.Vob.Name, Mathf.Max(1, vobContainer.VobAs<IItem>().Amount));

--- a/Assets/Gothic-VR/Scripts/Adapters/Player/VRBackpack.cs
+++ b/Assets/Gothic-VR/Scripts/Adapters/Player/VRBackpack.cs
@@ -87,7 +87,7 @@ namespace Gothic.VR.Adapters.Player
             var vobLoader = grabbable.GetComponentInParent<VobLoader>();
             var vobContainer = vobLoader.Container;
 
-            _playerService.AddItem(vobContainer.Vob.Name, vobContainer.VobAs<IItem>().Amount);
+            _playerService.AddItem(vobContainer.Vob.Name, Mathf.Max(1, vobContainer.VobAs<IItem>().Amount));
         }
 
 
@@ -102,8 +102,8 @@ namespace Gothic.VR.Adapters.Player
             _vobMeshCullingService.RemoveCullingEntry(vobContainer);
             _saveGameService.CurrentWorldData.Vobs.Remove(vobContainer.Vob);
 
-            _playerService.AddItem(vobContainer.Vob.Name, vobContainer.VobAs<IItem>().Amount);
-            
+            _playerService.AddItem(vobContainer.Vob.Name, Mathf.Max(1, vobContainer.VobAs<IItem>().Amount));
+
             UpdateInventoryView();
         }
 
@@ -116,21 +116,21 @@ namespace Gothic.VR.Adapters.Player
             var vobLoader = grabbable.GetComponentInParent<VobLoader>();
             var vobContainer = vobLoader.Container;
 
-            _playerService.RemoveItem(vobContainer.Vob.Name, vobContainer.VobAs<IItem>().Amount);
+            _playerService.RemoveItem(vobContainer.Vob.Name, Mathf.Max(1, vobContainer.VobAs<IItem>().Amount));
         }
 
         public void OnItemPutOutOfBackpack(HVRGrabberBase grabber, HVRGrabbable grabbable)
         {
             if (_tempIgnoreSocketing)
                 return;
-            
+
             var vobLoader = grabbable.GetComponentInParent<VobLoader>();
             var vobContainer = vobLoader.Container;
 
             _vobMeshCullingService.AddCullingEntry(vobContainer);
             _saveGameService.CurrentWorldData.Vobs.Add(vobContainer.Vob);
 
-            _playerService.RemoveItem(vobContainer.Vob.Name, vobContainer.VobAs<IItem>().Amount);
+            _playerService.RemoveItem(vobContainer.Vob.Name, Mathf.Max(1, vobContainer.VobAs<IItem>().Amount));
 
             UpdateInventoryView();
         }

--- a/Assets/Gothic-VR/Scripts/Adapters/VRNpc.cs
+++ b/Assets/Gothic-VR/Scripts/Adapters/VRNpc.cs
@@ -6,6 +6,7 @@ using Gothic.Core.Models.Vm;
 using Gothic.Core.Services;
 using Gothic.Core.Services.Config;
 using Gothic.Core.Services.Npc;
+using Gothic.Core.Services.World;
 using Gothic.Core;
 using Gothic.Core.Extensions;
 using HurricaneVR.Framework.Core;
@@ -22,6 +23,7 @@ namespace Gothic.VR.Adapters
         [Inject] private readonly DialogService _dialogService;
         [Inject] private readonly NpcAiService _npcAiService;
         [Inject] private readonly ConfigService _configService;
+        [Inject] private readonly PhysicsService _physicsService;
 
         private NpcContainer _npcData;
         private VRNpcLoot _npcLoot;
@@ -39,6 +41,9 @@ namespace Gothic.VR.Adapters
             if (isDead && _configService.Dev.EnableNpcLooting && _npcLoot != null)
             {
                 _npcLoot.Toggle(_npcData);
+                // HVR sets isKinematic=false during grab; release immediately and freeze the corpse
+                grabber.ForceRelease();
+                _physicsService.DisablePhysicsForNpc(_npcData.PrefabProps);
                 return;
             }
 


### PR DESCRIPTION
# Stabilizing v2 — NPC AI, Dialog, Inventory & VR fixes

A second round of stabilization fixes targeting NPC perception globals, dialog conditions, inventory checks, font rendering, and VR-specific edge cases.

---

## Changes by file

#### [`LiberationSans SDF empty.asset`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-730ebddc7bae9c483914301877c642ac67f53a04e8d7a935e708855f52049343)
Set atlas mode to Static. In Dynamic mode the empty atlas was being populated with Gothic characters on first render, causing them to render in Liberation Sans instead of the Gothic bitmap font. Static prevents any atlas population so all characters fall through to the `TMP_SpriteAsset` set by `AbstractMenu`/dialogs.

#### [`StatusBar.prefab`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-cc8865afc46f87edb47cc4ddaf8894fa617ca4ccb745732d763848c40eff6c4b)
Fixed HP bar appearing empty in PCVR headsets.

#### [`AnimationSystem.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-ca5d04e17c6c60f56020876dd2f5ca76be576bcef732d0672ed14d980ff95ad9)
Minor adjustment related to the death/hit animation bypass changes.

#### [`AiHandler.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-667d8c5e8e20091eb40770710ed2e4b58046991a760b6641ce4d77ba364d35a1)
- Set `GlobalOther = GlobalHero` before executing ZS_* state functions. After the perception save/restore was corrected in `NpcAiService`, a stale NPC (e.g. a Shadow guard) could remain in `GlobalOther` between perception calls — causing NPCs to turn their backs during conversations and guild/distance dialog conditions to evaluate against the wrong NPC.
- Added null guard for waypoint in `ReEnableNpc` + warning log for bad re-enables.

#### [`VobMeshCullingDomain.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-81052ac0715c9e6575e5d5a5c93cc6e17867327e1297c27e3826d4f9e4c4a330)
Skip destroyed `Rigidbody`s in `StopVobTrackingBasedOnVelocity` to prevent null-ref exceptions during VOB cleanup.

#### [`NpcHeadMeshBuilder.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-e779a1c5bf1f027d502b16490217a67aa9a7b125b88bb4cb9fe81d34742a8adc)
Null-safe `NpcLoader`/`Npc` access during async head construction — prevents crash when the NPC is destroyed before the build completes.

#### [`Attack.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-01e6c48f099b60033b66cd7e7a31d5c1c94515d8ded794aeb454f231ef63edec)
- Death animation now clears the queue and calls `StopAllAnimations` before playing, so dying always wins regardless of queued actions.
- Hurt animation overlays without interrupting the current action.
- `OnHit` early-outs if the target is already dead to prevent double damage/animation.
- `AI_Attack` is skipped with a log for human NPCs (`guild < GIL_SEPERATOR_HUM`) — not yet implemented for humans.

#### [`GoToNpc.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-ff16fd5e12d56c906d89514a04e60dd2356eef0c33f1903a3e0e05002dc43555)
NPCs now stop 1.5 m before the target instead of walking into them.

#### [`GoToWp.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-fe6bb474ac90084e7ca95ade72a87b44fd17ba73ca842953f07160c61c76676a)
`FindFastestPath` returning `null` no longer crashes — path is guarded before use.

#### [`VobInitializerDomain.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-36ceb8196bb3191436c00841f30901907c751e6bc51721f3ab68cc12d4b16619)
`InitVobCoroutine` now wraps each `InitVob` call in try/catch so a single broken VOB can't halt all lazy loading. Root cause: `BIRD/OWL NEAR MARKET` referenced `wood_night2` which doesn't exist in Gothic's `SfxInst.d`, causing `GetFirstSound()` to return null and silently kill the entire coroutine.

#### [`SfxModel.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-f5f3d15260b2dcc8f6581e3c739ed208d783795e8b4414e352766eea8f39278e)
Logs a warning when an SFX symbol is missing from the VM instead of silently returning null from `GetFirstSound`.

#### [`FightService.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-0c1ced8f0a5f58b06634058cfe242b5d318992378c33dd06e8828d4944b1b8fe)
Cooperates with the death animation bypass — HP reaching 0 sets `BodyState = BsDead` which `Npc_IsDead` now reads.

#### [`NpcAiService.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-bb572de575429dfab209d0df4eb83e77511463234889acc1b7a4002607732ba6)
- `GlobalOther`/`GlobalVictim` were incorrectly swapped during restore after perception calls (`oldOther` was assigned from `GlobalVictim` instead of `GlobalOther`), causing both globals to be set to the victim. Fixed save/restore order and replaced the fragile `npc2.Id == 0` hero check with an `Index` comparison against `GlobalHero`.
- `Npc_IsDead` was a `FIXME` stub hardcoded to `return false`. Now checks `Props.BodyState == BsDead`, fixing e.g. Thorus not recognizing Mordrag as dead after being killed.

#### [`NpcHelperService.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-cc79d24d9ae2b9085f11a64915c58fc26fd22f2511b4f16bfc25d54f9b794217)
`aiState` filter was comparing `npcVob.CurrentStateIndex` (the calling NPC's own state index) against each candidate, instead of comparing the requested `aiState` value.

#### [`NpcInventoryService.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-f5ba9331f38b892cef71e42ad9cd822500c62c59e15625dd06a7b78509e0dd8a)
`ExtNpcHasItems` was reading from `GetItem`/`ItemCount` (the VOB world-file list), which is never populated by runtime `CreateInvItems` calls. Rewrote to iterate all `InvCats` and read from `GetPacked` via `GetInventoryItems` — the same path used by all other inventory operations. Fixes `Npc_HasItems` always returning 0 for the player, breaking dialogs that check inventory (Fisk ore purchase, Bloodwyn extortion, Drax beer, etc.).

#### [`DialogService.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-99d0e1fbcf963edc939886dbccab2b979516d57cc92db4ceb984c4efb2391fc7)
Save/restore `GlobalOther` and set it to `GlobalHero` around `Info_*_Condition` calls, matching Gothic's convention (`self` = NPC, `other` = hero in all dialog condition functions). Prevents important dialogs from failing when a stale NPC was left in `GlobalOther`.

#### [`FontService.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-1f41dcf37f022d48ee60c89d72c201b9348230ed9d481376f273ccfa139cda22)
Pre-warms the TMP font atlas on startup by iterating all string-type Daedalus symbols, collecting unique characters, and calling `TryAddCharacters` before any UI renders. Prevents TMP fallback glyphs on first display of Gothic NPC/item names.

#### [`VobService.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-2d0ca7f626056a5e51481eb7bcdfc6edca9df2d6dd039669fd5f1cd1647fc02b)
World VOB items have `Amount = 0` by Gothic convention (single item = 0). Applied `Mathf.Max(1, amount)` so items picked up from the floor aren't stored as e.g. `ITFOBEERx0` in packed inventory.

#### [`BackPack.prefab`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/changes#diff-574e8b41a8c4706f081e40e91eff284b7b1a00672775ac9aa07d11a38f4e64ef)
Cleared placeholder texts (`"x/y"`, `"{{CATEGORY}}"`) that were triggering TMP warnings before boot because they rendered before `FontService` set the default sprite asset.

#### [`VRBackpack.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-4d2051c1178923a3f767d3e290ffe08190e382a9b84cd399552c37194be77408)
Added null guard for `vobLoader` in `OnItemPutOutOfHolster`. Also applies the `Mathf.Max(1, amount)` fix for picked-up item amounts.

#### [`VRNpc.cs`](https://github.com/Gothic-Unity-Project/Gothic-Unity/pull/367/files#diff-639f18942de24c2b9f3641b580f5798ee5b6d3a61cbf956ef127f8da275a6855)
HVR sets `isKinematic = false` on the grabbed `Rigidbody` during a grab, causing the NPC corpse to fall or be pushed by the player capsule after releasing. `ForceRelease` + `DisablePhysicsForNpc` are now called when opening the loot panel to keep the body frozen.

---

## How to test

1. Load the Old Camp and talk to Thorus — he should recognize Mordrag as dead (if killed) and dialog conditions should evaluate against the hero, not a nearby NPC.
2. Pick up items from the floor and check `Npc_HasItems` dialogs (Drax beer, Fisk ore) — they should work correctly.
3. Kill an NPC in VR and open the loot panel — the corpse should not fall or slide around.
4. Observe NPC routines — NPCs in conversation should face the player, not turn their backs.
5. Check the HP bar in-headset — should show correct values.
