### PR TITLE
Stack/02 vob loading

### DIFF
--- a/Assets/Gothic-Core/Scripts/Adapters/Scenes/WorldScene.cs
+++ b/Assets/Gothic-Core/Scripts/Adapters/Scenes/WorldScene.cs
@@ -165,6 +165,9 @@ namespace Gothic.Core.Adapters.Scenes
                     Logger.LogError(e.ToString(), LogCat.Loading);
                 }
 
+                // The culling sweep inside WorldSceneLoaded only _enqueued_ all VOBs around the spawn point for
+                // lazy initialization. InitVobCoroutine() drains the queue in the background while the player is
+                // already in the world - a brief pop-in is preferred over holding the loading screen any longer.
                 _loadingService.StopLoading();
                 SceneManager.UnloadSceneAsync(Constants.SceneLoading);
             }

--- a/Assets/Gothic-Core/Scripts/Adapters/Vob/VobLoader.cs
+++ b/Assets/Gothic-Core/Scripts/Adapters/Vob/VobLoader.cs
@@ -7,5 +7,6 @@ namespace Gothic.Core.Adapters.Vob
     {
         public VobContainer Container;
         public bool IsLoaded;
+        public bool IsQueued;
     }
 }

--- a/Assets/Gothic-Core/Scripts/Domain/Vobs/VobInitializerDomain.cs
+++ b/Assets/Gothic-Core/Scripts/Domain/Vobs/VobInitializerDomain.cs
@@ -291,7 +291,12 @@ namespace Gothic.Core.Domain.Vobs
                     go = _resourceCacheService.TryGetPrefabObject(PrefabType.VobSwitch, name: name, parent: parent);
                     break;
                 case VirtualObjectType.oCMobDoor:
-                    go = _resourceCacheService.TryGetPrefabObject(PrefabType.VobDoor, name: name, parent: parent);
+                    var visualName = vob.Visual?.Name;
+                    var isBed = !visualName.IsNullOrEmpty()
+                                && visualName.Split('_')[0].EqualsIgnoreCase("BED");
+                    go = isBed
+                        ? _resourceCacheService.TryGetPrefabObject(PrefabType.VobBed, name: name, parent: parent)
+                        : _resourceCacheService.TryGetPrefabObject(PrefabType.VobDoor, name: name, parent: parent);
                     break;
                 case VirtualObjectType.oCMobContainer:
                     go = _resourceCacheService.TryGetPrefabObject(PrefabType.VobContainer, name: name, parent: parent);

--- a/Assets/Gothic-Core/Scripts/Services/Vobs/VobService.cs
+++ b/Assets/Gothic-Core/Scripts/Services/Vobs/VobService.cs
@@ -55,6 +55,8 @@ namespace Gothic.Core.Services.Vobs
         private readonly char[] _itemCountSeparators = { ':', '.' };
 
 
+        private const int VobInitBatchSize = 10;
+
         private Dictionary<VirtualObjectType, GameObject> _vobTypeParentGOs = new();
         private Queue<VobLoader> _objectsToInitQueue = new();
 
@@ -138,16 +140,14 @@ namespace Gothic.Core.Services.Vobs
         {
             go.TryGetComponent(out VobLoader loaderComp);
 
-            if (loaderComp == null || loaderComp.IsLoaded)
+            // IsQueued ensures we do not add elements to be loaded twice (without an O(n) Queue.Contains() check).
+            if (loaderComp == null || loaderComp.IsLoaded || loaderComp.IsQueued)
             {
                 return;
             }
-            
-            // Do not add elements to be loaded twice.
-            if (_objectsToInitQueue.Contains(loaderComp))
-                return;
 
-            _objectsToInitQueue.Enqueue(go.GetComponent<VobLoader>());
+            loaderComp.IsQueued = true;
+            _objectsToInitQueue.Enqueue(loaderComp);
         }
 
         // DEBUG - Check how many frames it took to initialize all the objects
@@ -175,19 +175,27 @@ namespace Gothic.Core.Services.Vobs
                     //     firstFrameQueueFilledUp = Time.frameCount;
                     // }
 
-                    var item = _objectsToInitQueue.Dequeue();
-
-                    item.IsLoaded = true;
-
-                    // We assume that each loaded VOB is centered at parent=0,0,0.
-                    // Should work smoothly until we start lazy loading sub-vobs ;-)
-                    try
+                    for (var i = 0; i < VobInitBatchSize && !_objectsToInitQueue.IsEmpty(); i++)
                     {
-                        _initializerDomain.InitVob(item.Container.Vob, item.gameObject, default, true);
-                    }
-                    catch (Exception e)
-                    {
-                        Logger.LogError($"Failed to init VOB {item.name}: {e}", LogCat.Vob);
+                        var item = _objectsToInitQueue.Dequeue();
+
+                        // Destroyed in the meantime (e.g. world change).
+                        if (item == null)
+                            continue;
+
+                        item.IsLoaded = true;
+
+                        // We assume that each loaded VOB is centered at parent=0,0,0.
+                        // Should work smoothly until we start lazy loading sub-vobs ;-)
+                        try
+                        {
+                            _initializerDomain.InitVob(item.Container.Vob, item.gameObject, default, true);
+                        }
+                        catch (Exception e)
+                        {
+                            Logger.LogError($"Failed to init VOB {item.name}: {e}", LogCat.Vob);
+                        }
+                        
                     }
 
                     yield return _frameSkipperService.TrySkipToNextFrameCoroutine();
@@ -241,6 +249,9 @@ namespace Gothic.Core.Services.Vobs
 
             // We reset the GO dictionary.
             _vobTypeParentGOs = new();
+
+            // Drop pending lazy-init entries from a previous world. Their VobLoader GOs are destroyed by now.
+            _objectsToInitQueue.Clear();
 
             ObjectRoutines.ClearAndReleaseMemory();
             ObjectRoutines = new();

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -8,7 +8,7 @@ PlayerSettings:
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
   AndroidEnableSustainedPerformanceMode: 0
-  defaultScreenOrientation: 4
+  defaultScreenOrientation: 3
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
@@ -17,8 +17,8 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 1
-  m_ShowUnitySplashLogo: 1
+  m_ShowUnitySplashScreen: 0
+  m_ShowUnitySplashLogo: 0
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
   m_SplashScreenLogoStyle: 1
@@ -285,7 +285,7 @@ PlayerSettings:
   AndroidEnableTango: 0
   androidEnableBanner: 1
   androidUseLowAccuracyLocation: 0
-  androidUseCustomKeystore: 1
+  androidUseCustomKeystore: 0
   m_AndroidBanners:
   - width: 320
     height: 180
@@ -536,7 +536,7 @@ PlayerSettings:
   - m_BuildTarget: LuminSupport
     m_GraphicsJobs: 0
   - m_BuildTarget: AndroidPlayer
-    m_GraphicsJobs: 0
+    m_GraphicsJobs: 1
   - m_BuildTarget: WebGLSupport
     m_GraphicsJobs: 0
   m_BuildTargetGraphicsJobMode:
@@ -559,6 +559,9 @@ PlayerSettings:
     m_Automatic: 1
   - m_BuildTarget: WindowsStandaloneSupport
     m_APIs: 0200000012000000
+    m_Automatic: 0
+  - m_BuildTarget: LinuxStandaloneSupport
+    m_APIs: 1500000011000000
     m_Automatic: 0
   m_BuildTargetVRSettings:
   - m_BuildTarget: Standalone
@@ -875,8 +878,8 @@ PlayerSettings:
   webWasm2023: 0
   webEnableSubmoduleStrippingCompatibility: 0
   scriptingDefineSymbols:
-    Android: USE_INPUT_SYSTEM_POSE_CONTROL;ENABLE_UBERLOGGING;GOTHIC_HVR_INSTALLED;SENTIS_ANALYTICS_ENABLED;APP_UI_EDITOR_ONLY
-    Standalone: USE_INPUT_SYSTEM_POSE_CONTROL;ENABLE_UBERLOGGING;GOTHIC_HVR_INSTALLED;SENTIS_ANALYTICS_ENABLED;APP_UI_EDITOR_ONLY
+    Android: USE_INPUT_SYSTEM_POSE_CONTROL;ENABLE_UBERLOGGING;GOTHIC_HVR_INSTALLED;APP_UI_EDITOR_ONLY
+    Standalone: USE_INPUT_SYSTEM_POSE_CONTROL;ENABLE_UBERLOGGING;GOTHIC_HVR_INSTALLED;APP_UI_EDITOR_ONLY
     Windows Store Apps: USE_INPUT_SYSTEM_POSE_CONTROL
   additionalCompilerArguments: {}
   platformArchitecture: {}

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -157,7 +157,7 @@ QualitySettings:
     - Android
   m_TextureMipmapLimitGroupNames: []
   m_PerPlatformDefaultQuality:
-    Android: 1
+    Android: 0
     Lumin: 2
     Nintendo 3DS: 2
     Nintendo Switch: 2


### PR DESCRIPTION
## Summary
Reduces VOB lazy-init overhead and fixes bed VOBs spawning the wrong prefab.

## Changes
- **Queue dedup** — replaces the O(n) `Queue.Contains()` guard with a per-loader `IsQueued` flag; the init queue is batch-drained (10/frame), skips entries destroyed in the meantime, and is cleared on world change so stale entries from the previous world are dropped.
- **Bed prefab routing** — `oCMobDoor` VOBs whose visual name starts with `BED_` now resolve the `VobBed` prefab instead of `VobDoor`.

## How to test
- Load a populated world and confirm VOBs stream in without the previous Contains() hitch; Should load the vobs faster.
- go near a bed and check that you don't get spammed with errors regarding door locks